### PR TITLE
[ethers-v5] Generate and export typed events

### DIFF
--- a/.changeset/good-starfishes-appear.md
+++ b/.changeset/good-starfishes-appear.md
@@ -1,6 +1,5 @@
 ---
 '@typechain/ethers-v5': minor
-'@typechain/ethers-v5-test': minor
 ---
 
 Export typed events

--- a/.changeset/good-starfishes-appear.md
+++ b/.changeset/good-starfishes-appear.md
@@ -1,0 +1,6 @@
+---
+'@typechain/ethers-v5': minor
+'@typechain/ethers-v5-test': minor
+---
+
+Export typed events

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
@@ -100,7 +100,7 @@ interface ERC20Interface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "Transfer"): EventFragment;
 }
 
-export type ApprovalEvent = TypedEvent<
+export type Approval_TypedEvent = TypedEvent<
   [string, string, BigNumber] & {
     owner: string;
     spender: string;
@@ -108,7 +108,7 @@ export type ApprovalEvent = TypedEvent<
   }
 >;
 
-export type TransferEvent = TypedEvent<
+export type Transfer_TypedEvent = TypedEvent<
   [string, string, BigNumber] & { from: string; to: string; value: BigNumber }
 >;
 

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
@@ -100,6 +100,18 @@ interface ERC20Interface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "Transfer"): EventFragment;
 }
 
+export type ApprovalEvent = TypedEvent<
+  [string, string, BigNumber] & {
+    owner: string;
+    spender: string;
+    value: BigNumber;
+  }
+>;
+
+export type TransferEvent = TypedEvent<
+  [string, string, BigNumber] & { from: string; to: string; value: BigNumber }
+>;
+
 export class ERC20 extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
   attach(addressOrName: string): this;

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
@@ -100,7 +100,7 @@ interface ERC20Interface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "Transfer"): EventFragment;
 }
 
-export type Approval_TypedEvent = TypedEvent<
+export type ApprovalEvent = TypedEvent<
   [string, string, BigNumber] & {
     owner: string;
     spender: string;
@@ -108,7 +108,7 @@ export type Approval_TypedEvent = TypedEvent<
   }
 >;
 
-export type Transfer_TypedEvent = TypedEvent<
+export type TransferEvent = TypedEvent<
   [string, string, BigNumber] & { from: string; to: string; value: BigNumber }
 >;
 

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/ERC20.d.ts
@@ -301,6 +301,15 @@ export class ERC20 extends BaseContract {
   };
 
   filters: {
+    "Approval(address,address,uint256)"(
+      owner?: string | null,
+      spender?: string | null,
+      value?: null
+    ): TypedEventFilter<
+      [string, string, BigNumber],
+      { owner: string; spender: string; value: BigNumber }
+    >;
+
     Approval(
       owner?: string | null,
       spender?: string | null,
@@ -308,6 +317,15 @@ export class ERC20 extends BaseContract {
     ): TypedEventFilter<
       [string, string, BigNumber],
       { owner: string; spender: string; value: BigNumber }
+    >;
+
+    "Transfer(address,address,uint256)"(
+      from?: string | null,
+      to?: string | null,
+      value?: null
+    ): TypedEventFilter<
+      [string, string, BigNumber],
+      { from: string; to: string; value: BigNumber }
     >;
 
     Transfer(

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -95,4 +95,17 @@ describe('Events', () => {
       typedAssert(r.args[1], BigNumber.from(2))
     })
   })
+
+  it('queryFilter overloaded event', async () => {
+    await contract.emit_event3_overloaded()
+
+    const filter = contract.filters.Event3()
+    const results = await contract.queryFilter(filter)
+    results.map((r) => {
+      typedAssert(r.args.value1, true)
+      typedAssert(r.args.value2, BigNumber.from(2))
+      typedAssert(r.args[0], true)
+      typedAssert(r.args[1], BigNumber.from(2))
+    })
+  })
 })

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ethers } from 'ethers'
 import { typedAssert } from 'test-utils'
 
-import { Events } from '../types/Events'
+import { Event1Event, Events } from '../types/Events'
 import { createNewBlockchain, deployContract } from './common'
 
 describe('Events', () => {
@@ -83,5 +83,16 @@ describe('Events', () => {
 
     await contract.emit_event1()
     await new Promise((r) => setTimeout(r, 1000))
+  })
+
+  it('typed event import', async () => {
+    const filter = contract.filters.Event1(null, null)
+    const results = (await contract.queryFilter(filter)) as any
+    ;(results as Event1Event[]).map((r) => {
+      typedAssert(r.args.value1, BigNumber.from(1))
+      typedAssert(r.args.value2, BigNumber.from(2))
+      typedAssert(r.args[0], BigNumber.from(1))
+      typedAssert(r.args[1], BigNumber.from(2))
+    })
   })
 })

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ethers } from 'ethers'
 import { typedAssert } from 'test-utils'
 
-import { Event1Event, Events } from '../types/Events'
+import { Event1_TypedEvent, Events } from '../types/Events'
 import { createNewBlockchain, deployContract } from './common'
 
 describe('Events', () => {
@@ -88,7 +88,7 @@ describe('Events', () => {
   it('typed event import', async () => {
     const filter = contract.filters.Event1(null, null)
     const results = (await contract.queryFilter(filter)) as any
-    ;(results as Event1Event[]).map((r) => {
+    ;(results as Event1_TypedEvent[]).map((r) => {
       typedAssert(r.args.value1, BigNumber.from(1))
       typedAssert(r.args.value2, BigNumber.from(2))
       typedAssert(r.args[0], BigNumber.from(1))

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ethers } from 'ethers'
 import { typedAssert } from 'test-utils'
 
-import { Event1_TypedEvent, Events } from '../types/Events'
+import { Event1Event, Events } from '../types/Events'
 import { createNewBlockchain, deployContract } from './common'
 
 describe('Events', () => {
@@ -88,7 +88,9 @@ describe('Events', () => {
   it('typed event import', async () => {
     const filter = contract.filters.Event1(null, null)
     const results = (await contract.queryFilter(filter)) as any
-    ;(results as Event1_TypedEvent[]).map((r) => {
+
+    const results2 = results as Event1Event[]
+    results2.map((r) => {
       typedAssert(r.args.value1, BigNumber.from(1))
       typedAssert(r.args.value2, BigNumber.from(2))
       typedAssert(r.args[0], BigNumber.from(1))

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -99,13 +99,23 @@ describe('Events', () => {
   it('queryFilter overloaded event', async () => {
     await contract.emit_event3_overloaded()
 
-    const filter = contract.filters.Event3()
-    const results = await contract.queryFilter(filter)
-    results.map((r) => {
-      typedAssert(r.args.value1, true)
-      typedAssert(r.args.value2, BigNumber.from(2))
-      typedAssert(r.args[0], true)
-      typedAssert(r.args[1], BigNumber.from(2))
-    })
+    {
+      const filterA = contract.filters['Event3(bool,uint256)']()
+      const results = await contract.queryFilter(filterA)
+      results.map((r) => {
+        typedAssert(r.args.value1, true)
+        typedAssert(r.args.value2, BigNumber.from(2))
+        typedAssert(r.args[0], true)
+        typedAssert(r.args[1], BigNumber.from(2))
+      })
+    }
+    {
+      const filterB = contract.filters['Event3(uint256)']()
+      const results = await contract.queryFilter(filterB)
+      results.map((r) => {
+        typedAssert(r.args.value1, BigNumber.from(1))
+        typedAssert(r.args[0], BigNumber.from(1))
+      })
+    }
   })
 })

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -221,9 +221,21 @@ export class Events extends BaseContract {
   };
 
   filters: {
+    "AnonEvent1(uint256)"(
+      value1?: BigNumberish | null
+    ): TypedEventFilter<[BigNumber], { value1: BigNumber }>;
+
     AnonEvent1(
       value1?: BigNumberish | null
     ): TypedEventFilter<[BigNumber], { value1: BigNumber }>;
+
+    "Event1(uint256,uint256)"(
+      value1?: BigNumberish | null,
+      value2?: null
+    ): TypedEventFilter<
+      [BigNumber, BigNumber],
+      { value1: BigNumber; value2: BigNumber }
+    >;
 
     Event1(
       value1?: BigNumberish | null,
@@ -233,16 +245,31 @@ export class Events extends BaseContract {
       { value1: BigNumber; value2: BigNumber }
     >;
 
+    "Event2(uint256)"(
+      undefined?: null
+    ): TypedEventFilter<[BigNumber], { arg0: BigNumber }>;
+
     Event2(
       undefined?: null
     ): TypedEventFilter<[BigNumber], { arg0: BigNumber }>;
 
-    Event3(
+    "Event3(bool,uint256)"(
       value1?: boolean | null,
       value2?: null
     ): TypedEventFilter<
       [boolean, BigNumber],
       { value1: boolean; value2: BigNumber }
+    >;
+
+    "Event3(uint256)"(
+      value1?: BigNumberish | null
+    ): TypedEventFilter<[BigNumber], { value1: BigNumber }>;
+
+    "Event4(tuple)"(
+      data?: null
+    ): TypedEventFilter<
+      [[BigNumber, string] & { index: BigNumber; name: string }],
+      { data: [BigNumber, string] & { index: BigNumber; name: string } }
     >;
 
     Event4(
@@ -251,6 +278,8 @@ export class Events extends BaseContract {
       [[BigNumber, string] & { index: BigNumber; name: string }],
       { data: [BigNumber, string] & { index: BigNumber; name: string } }
     >;
+
+    "NoArgsEvent()"(): TypedEventFilter<[], {}>;
 
     NoArgsEvent(): TypedEventFilter<[], {}>;
   };

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -93,6 +93,26 @@ interface EventsInterface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "NoArgsEvent"): EventFragment;
 }
 
+export type AnonEvent1Event = TypedEvent<[BigNumber] & { value1: BigNumber }>;
+
+export type Event1Event = TypedEvent<
+  [BigNumber, BigNumber] & { value1: BigNumber; value2: BigNumber }
+>;
+
+export type Event2Event = TypedEvent<[BigNumber] & { arg0: BigNumber }>;
+
+export type Event3Event = TypedEvent<
+  [boolean, BigNumber] & { value1: boolean; value2: BigNumber }
+>;
+
+export type Event4Event = TypedEvent<
+  [[BigNumber, string] & { index: BigNumber; name: string }] & {
+    data: [BigNumber, string] & { index: BigNumber; name: string };
+  }
+>;
+
+export type NoArgsEventEvent = TypedEvent<[] & {}>;
+
 export class Events extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
   attach(addressOrName: string): this;

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -93,31 +93,29 @@ interface EventsInterface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "NoArgsEvent"): EventFragment;
 }
 
-export type AnonEvent1_TypedEvent = TypedEvent<
-  [BigNumber] & { value1: BigNumber }
->;
+export type AnonEvent1Event = TypedEvent<[BigNumber] & { value1: BigNumber }>;
 
-export type Event1_TypedEvent = TypedEvent<
+export type Event1Event = TypedEvent<
   [BigNumber, BigNumber] & { value1: BigNumber; value2: BigNumber }
 >;
 
-export type Event2_TypedEvent = TypedEvent<[BigNumber] & { arg0: BigNumber }>;
+export type Event2Event = TypedEvent<[BigNumber] & { arg0: BigNumber }>;
 
-export type Event3_bool_uint256_TypedEvent = TypedEvent<
+export type Event3_bool_uint256_Event = TypedEvent<
   [boolean, BigNumber] & { value1: boolean; value2: BigNumber }
 >;
 
-export type Event3_uint256_TypedEvent = TypedEvent<
+export type Event3_uint256_Event = TypedEvent<
   [BigNumber] & { value1: BigNumber }
 >;
 
-export type Event4_TypedEvent = TypedEvent<
+export type Event4Event = TypedEvent<
   [[BigNumber, string] & { index: BigNumber; name: string }] & {
     data: [BigNumber, string] & { index: BigNumber; name: string };
   }
 >;
 
-export type NoArgsEvent_TypedEvent = TypedEvent<[] & {}>;
+export type NoArgsEventEvent = TypedEvent<[] & {}>;
 
 export class Events extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;

--- a/packages/target-ethers-v5-test/types/Events.d.ts
+++ b/packages/target-ethers-v5-test/types/Events.d.ts
@@ -93,25 +93,31 @@ interface EventsInterface extends ethers.utils.Interface {
   getEvent(nameOrSignatureOrTopic: "NoArgsEvent"): EventFragment;
 }
 
-export type AnonEvent1Event = TypedEvent<[BigNumber] & { value1: BigNumber }>;
+export type AnonEvent1_TypedEvent = TypedEvent<
+  [BigNumber] & { value1: BigNumber }
+>;
 
-export type Event1Event = TypedEvent<
+export type Event1_TypedEvent = TypedEvent<
   [BigNumber, BigNumber] & { value1: BigNumber; value2: BigNumber }
 >;
 
-export type Event2Event = TypedEvent<[BigNumber] & { arg0: BigNumber }>;
+export type Event2_TypedEvent = TypedEvent<[BigNumber] & { arg0: BigNumber }>;
 
-export type Event3Event = TypedEvent<
+export type Event3_bool_uint256_TypedEvent = TypedEvent<
   [boolean, BigNumber] & { value1: boolean; value2: BigNumber }
 >;
 
-export type Event4Event = TypedEvent<
+export type Event3_uint256_TypedEvent = TypedEvent<
+  [BigNumber] & { value1: BigNumber }
+>;
+
+export type Event4_TypedEvent = TypedEvent<
   [[BigNumber, string] & { index: BigNumber; name: string }] & {
     data: [BigNumber, string] & { index: BigNumber; name: string };
   }
 >;
 
-export type NoArgsEventEvent = TypedEvent<[] & {}>;
+export type NoArgsEvent_TypedEvent = TypedEvent<[] & {}>;
 
 export class Events extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -341,8 +341,8 @@ function generateEventTypeExport(event: EventDeclaration, includeArgTypes: boole
 
   return `
 export type ${event.name}${
-    includeArgTypes ? event.inputs.map((input) => '_' + input.type.originalType).join('') : ''
-  }_TypedEvent = TypedEvent<${arrayOutput} & ${objectOutput}>;
+    includeArgTypes ? event.inputs.map((input) => '_' + input.type.originalType).join('') + '_Event' : 'Event'
+  } = TypedEvent<${arrayOutput} & ${objectOutput}>;
 `
 }
 

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -72,6 +72,11 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
       .join('\n')}
   }
 
+  ${values(contract.events)
+    .map((v) => v[0])
+    .map(generateEventTypeExport)
+    .join('\n')}
+
   export class ${contract.name} extends BaseContract {
     connect(signerOrProvider: Signer | Provider | string): this;
     attach(addressOrName: string): this;
@@ -119,7 +124,7 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
     filters: {
       ${values(contract.events)
         .map((v) => v[0])
-        .map(generateEvents)
+        .map(generateEventFilter)
         .join('\n')}
     };
 
@@ -301,13 +306,23 @@ function generateParamNames(params: Array<AbiParameter | EventArgDeclaration>): 
   return params.map((param, index) => param.name || `arg${index}`).join(', ')
 }
 
-function generateEvents(event: EventDeclaration) {
+function generateEventFilter(event: EventDeclaration) {
   const components = event.inputs.map((input, i) => ({ name: input.name ?? `arg${i.toString()}`, type: input.type }))
   const arrayOutput = generateOutputComplexTypeAsArray(components)
   const objectOutput = generateOutputComplexTypesAsObject(components) || '{}'
 
   return `
   ${event.name}(${generateEventTypes(event.inputs)}): TypedEventFilter<${arrayOutput}, ${objectOutput}>;
+`
+}
+
+function generateEventTypeExport(event: EventDeclaration) {
+  const components = event.inputs.map((input, i) => ({ name: input.name ?? `arg${i.toString()}`, type: input.type }))
+  const arrayOutput = generateOutputComplexTypeAsArray(components)
+  const objectOutput = generateOutputComplexTypesAsObject(components) || '{}'
+
+  return `
+export type ${event.name}Event = TypedEvent<${arrayOutput} & ${objectOutput}>;
 `
 }
 


### PR DESCRIPTION
Usage

```ts
import type { Transfer_TypedEvent } from '../typechain/MyErc20Token';

// overloaded events
import type { Execute_bytes32_TypedEvent, Execute_address_bytes_TypedEvent } from '../typechain/MyMultisig';

// ...

const parsed = contract.interface.parseLog(log) as TransferEvent;
parsed.args.from // string
parsed.args.to // string
parsed.args.value // BigNumber
```

#440