### PR TITLE
hardhat: include typechain in sample tsconfig.json

### DIFF
--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -57,7 +57,7 @@ Here's a sample `tsconfig.json`:
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["./scripts", "./test"],
+  "include": ["./scripts", "./test", "./typechain"],
   "files": ["./hardhat.config.ts"]
 }
 ```


### PR DESCRIPTION
The sample tsconfig.json was missing the hardhat folder, possibly making it confusing for people expecting:

- **Frictionless** - return type of `ethers.getContractFactory` will be typed properly - no need for casts

Fixes #460