### PR TITLE
typechain: Add missing peer dependency on typescript

### DIFF
--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -59,6 +59,6 @@
     "glob": "^7.1.2"
   },
   "peerDependencies": {
-    "typescript": "4.1.5"
+    "typescript": ">=4.1.0"
   }
 }

--- a/packages/typechain/package.json
+++ b/packages/typechain/package.json
@@ -57,5 +57,8 @@
     "bluebird": "^3.5.1",
     "coveralls": "^3.0.2",
     "glob": "^7.1.2"
+  },
+  "peerDependencies": {
+    "typescript": "4.1.5"
   }
 }


### PR DESCRIPTION
The peer dependency on typescript is required to satisfy the peer dependency requirements of ts-essentials.

Adding the peer dependency eliminates a warning in our build which uses typechain.


Thanks for a great tool!