### PR TITLE
[ethers-v5] fix for getContractAt incorrect type

### DIFF
--- a/.changeset/unlucky-ties-beg.md
+++ b/.changeset/unlucky-ties-beg.md
@@ -1,0 +1,5 @@
+---
+'@typechain/ethers-v5': patch
+---
+
+Fix typing for `getContractAt` when using Hardhat

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/hardhat.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/hardhat.d.ts
@@ -37,27 +37,27 @@ declare module "hardhat/types/runtime" {
       name: "EdgeCases",
       address: string,
       signer?: ethers.Signer
-    ): Promise<Contracts.EdgeCases__factory>;
+    ): Promise<Contracts.EdgeCases>;
     getContractAt(
       name: "SafeMath",
       address: string,
       signer?: ethers.Signer
-    ): Promise<Contracts.SafeMath__factory>;
+    ): Promise<Contracts.SafeMath>;
     getContractAt(
       name: "TestContract",
       address: string,
       signer?: ethers.Signer
-    ): Promise<Contracts.TestContract__factory>;
+    ): Promise<Contracts.TestContract>;
     getContractAt(
       name: "TestContract1",
       address: string,
       signer?: ethers.Signer
-    ): Promise<Contracts.TestContract1__factory>;
+    ): Promise<Contracts.TestContract1>;
     getContractAt(
       name: "ERC20",
       address: string,
       signer?: ethers.Signer
-    ): Promise<Contracts.ERC20__factory>;
+    ): Promise<Contracts.ERC20>;
 
     // default types
     getContractFactory(

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain/hardhat.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain/hardhat.d.ts
@@ -69,10 +69,10 @@ declare module "hardhat/types/runtime" {
       bytecode: ethers.utils.BytesLike,
       signer?: ethers.Signer
     ): Promise<ethers.ContractFactory>;
-    getContractAt: (
+    getContractAt(
       nameOrAbi: string | any[],
       address: string,
       signer?: ethers.Signer
-    ) => Promise<ethers.Contract>;
+    ): Promise<ethers.Contract>;
   }
 }

--- a/packages/target-ethers-v5/src/codegen/hardhat.ts
+++ b/packages/target-ethers-v5/src/codegen/hardhat.ts
@@ -20,12 +20,7 @@ declare module "hardhat/types/runtime" {
     .join('\n')}
 
   ${contracts
-    .map(
-      (n) =>
-        `getContractAt(name: '${n}', address: string, signer?: ethers.Signer): Promise<Contracts.${
-          n + FACTORY_POSTFIX
-        }>`,
-    )
+    .map((n) => `getContractAt(name: '${n}', address: string, signer?: ethers.Signer): Promise<Contracts.${n}>`)
     .join('\n')}
 
     // default types

--- a/packages/target-ethers-v5/src/codegen/hardhat.ts
+++ b/packages/target-ethers-v5/src/codegen/hardhat.ts
@@ -33,11 +33,11 @@ declare module "hardhat/types/runtime" {
       bytecode: ethers.utils.BytesLike,
       signer?: ethers.Signer
     ): Promise<ethers.ContractFactory>;
-    getContractAt: (
+    getContractAt(
       nameOrAbi: string | any[],
       address: string,
       signer?: ethers.Signer
-    ) => Promise<ethers.Contract>;
+    ): Promise<ethers.Contract>;
   }
 }
   `


### PR DESCRIPTION
The PR https://github.com/dethcrypto/TypeChain/pull/473 introduced a bug that the getContractAt returns a factory type. But it should return a contract type instead. This PR aims to fix this.