### PR TITLE
Basic works-for-me hack to use .ts interfaces rather than .d.ts

### DIFF
--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -40,7 +40,7 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
   import { FunctionFragment, EventFragment, Result } from '@ethersproject/abi';
   import type { TypedEventFilter, TypedEvent, TypedListener } from './common';
 
-  interface ${contract.name}Interface extends ethers.utils.Interface {
+  export interface ${contract.name}Interface extends ethers.utils.Interface {
     functions: {
       ${values(contract.functions)
         .map((v) => v[0])
@@ -73,7 +73,7 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
 
   ${values(contract.events).map(generateEventTypeExports).join('\n')}
 
-  export class ${contract.name} extends BaseContract {
+  export interface ${contract.name} extends BaseContract {
     connect(signerOrProvider: Signer | Provider | string): this;
     attach(addressOrName: string): this;
     deployed(): Promise<this>;

--- a/packages/target-ethers-v5/src/index.ts
+++ b/packages/target-ethers-v5/src/index.ts
@@ -109,7 +109,7 @@ export default class Ethers extends TypeChainTarget {
 
   genContractTypingsFile(contract: Contract, codegenConfig: CodegenConfig): FileDescription {
     return {
-      path: join(this.outDirAbs, `${contract.name}.d.ts`),
+      path: join(this.outDirAbs, `${contract.name}.ts`),
       contents: codegenContractTypings(contract, codegenConfig),
     }
   }


### PR DESCRIPTION
declarations so that compiles includes type declarations in build
output of typechain-based projects.

https://github.com/dethcrypto/TypeChain/issues/430

Signed-off-by: Silas Davis <silas@monax.io>