### PR TITLE
Include *.js files in tsconfig.json for ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/** @type {import("eslint").Linter.Config} */
 module.exports = {
   env: {
     es6: true,
@@ -11,7 +12,7 @@ module.exports = {
   },
   rules: {
     // this gets inlined into a package eslint, so it means: use current package's package.info or the one at the project root
-    'import/no-extraneous-dependencies': ['error', { packageDir: ['./', '../../'] }],
+    'import/no-extraneous-dependencies': ['error', { packageDir: ['./', __dirname] }],
     'unused-imports/no-unused-imports-ts': 'error',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "composite": true,
     "incremental": true
   },
-  "include": ["packages/**/*.ts"],
+  "include": ["packages/**/*.ts", "packages/**/*.js", "**/.*.js"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## What's the problem?

I started to work on Windows issues and I noticed ESLint is panicking in JS files, because they're not included in the _tsconfig.json_.

![image](https://user-images.githubusercontent.com/15332326/135709234-30955868-948a-4650-b2d4-c65af62eba36.png)

It could safely be disregarded, but since a red squiggly line looks the same as a type error in my IDE, I decided it won't hurt to fix it.

## What's changed?

Noticing that the project uses _tsconfig.json_ files for development and _tsconfig.build.json_ files for production builds, I added JS files to the root _tsconfig.json_. I considered adding a new file — _tsconfig.eslint.json_ — but if this change to _tsconfig.json_ doesn't break anything I suppose it's better to keep it minimal.

However, led me to another problem — I expect this one happens because I'm on Windows.

```
❯ yarn eslint ./.eslintrc.js

D:\workspace\TypeChain\.eslintrc.js
  0:1  error  The package.json file could not be found  import/no-extraneous-dependencies
```

So I changed one of `packageDir`s in _eslintrc.js_ from `'../../'` to `__dirname`.

Recognizing that @krzkaczor is a fellow TypeScript aficionado, I have also sprinkled a type annotation in the root _.eslintrc.js_ file.

---

BTW I noticed a Changesets config in the repo, but there's no mention of changesets in the _CONTIRBUTING.md_, so I also wanted to ask about it. Anyway, I suppose there's no need for a changeset here, because this doesn't affect the code at all.