### PR TITLE
Fix structName for nested array of struct

### DIFF
--- a/.changeset/silver-foxes-remember.md
+++ b/.changeset/silver-foxes-remember.md
@@ -1,0 +1,5 @@
+---
+"typechain": patch
+---
+
+Fix `structName` for nested array of struct

--- a/packages/typechain/src/parser/parseEvmType.ts
+++ b/packages/typechain/src/parser/parseEvmType.ts
@@ -131,8 +131,8 @@ export function extractStructNameIfAvailable(internalType: string | undefined): 
   if (internalType?.startsWith('struct ')) {
     // get rid of "struct " in the beginning
     let nameStr = internalType.slice(7)
-    // get rid of the array sign at the end
-    const arrayMarker = nameStr.match(/(\[\d*\])$/)?.[1]
+    // get rid of all array signs at the end
+    const arrayMarker = nameStr.match(/((?:\[\d*\])+)$/)?.[1]
     if (arrayMarker) {
       nameStr = nameStr.slice(0, nameStr.length - arrayMarker.length)
     }

--- a/packages/typechain/test/parser/parseEvmType.test.ts
+++ b/packages/typechain/test/parser/parseEvmType.test.ts
@@ -134,6 +134,34 @@ describe('parseEvmType function', () => {
     })
   })
 
+  it('parses struct nested array', () => {
+    const parsedType = parseEvmType(
+      'tuple[][]',
+      [
+        { name: 'target', type: { type: 'address', originalType: 'address' } },
+        { name: 'callData', type: { type: 'dynamic-bytes', originalType: 'bytes' } },
+      ],
+      'struct Multicall.Call[][]',
+    )
+    expect(parsedType).toEqual({
+      type: 'array',
+      itemType: {
+        type: 'array',
+        itemType: {
+          type: 'tuple',
+          components: [
+            { name: 'target', type: { type: 'address', originalType: 'address' } },
+            { name: 'callData', type: { type: 'dynamic-bytes', originalType: 'bytes' } },
+          ],
+          originalType: 'tuple',
+        },
+        originalType: 'tuple[]',
+      },
+      originalType: 'tuple[][]',
+      structName: 'Call',
+    })
+  })
+
   it('parses constant size struct arrays', () => {
     const actual = parseEvmType(
       'tuple[2]',


### PR DESCRIPTION
I think this is only relevant for ethers-v5 - I had an error with it and my function that returns Struct[][]