### PR TITLE
Disable no-unused-import-ts ESLint rule if running inside VSCode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const inTextEditor = process.env.VSCODE_PID !== undefined
+
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   env: {
@@ -16,7 +18,7 @@ module.exports = {
     'no-invalid-this': 'off',
     // this gets inlined into a package eslint, so it means: use current package's package.info or the one at the project root
     'import/no-extraneous-dependencies': ['error', { packageDir: ['./', __dirname] }],
-    'unused-imports/no-unused-imports-ts': 'error',
+    'unused-imports/no-unused-imports-ts': inTextEditor ? 'off' : 'error',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     '@typescript-eslint/no-use-before-define': 'off',


### PR DESCRIPTION
POV:

1. You import a thing.
2. You save the file.
3. The import declaration you just wrote dissapears.

---

`unused-imports/no-unused-imports-ts` is an evil rule to run inside of a text editor. I've been trying to live with it for two months, but enough is enough :P What's worse, I have autosave enabled, so I import a thing, wait a second and it dissapears :>

`VSCODE_PID` is not set when we run ESLint from the CLI so unused imports will be safely removed in `yarn test:fix`.