### PR TITLE
Multiple struct inputs with same name

### DIFF
--- a/.changeset/pretty-waves-leave.md
+++ b/.changeset/pretty-waves-leave.md
@@ -1,0 +1,6 @@
+---
+'@typechain/ethers-v5': major
+'typechain': major
+---
+
+Structs will be namespaced using contract name when available

--- a/contracts/v0.6.4/DataTypesInput.sol
+++ b/contracts/v0.6.4/DataTypesInput.sol
@@ -70,4 +70,23 @@ contract DataTypesInput {
   function input_struct2_tuple(Struct2[3] memory input) public pure returns (Struct2[3] memory) {
     return input;
   }
+
+  function input_multiple_structs_with_same_name(StructsLib1.Info memory info1) public pure returns (StructsLib2.Info memory info2) {
+    info2.a = address(info1.a);
+    info2.b = address(info1.b);
+  }
+}
+
+library StructsLib1 {
+  struct Info {
+    uint160 a;
+    uint160 b;
+  }
+}
+
+library StructsLib2 {
+  struct Info {
+    address a;
+    address b;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/mocha": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "4.15.1",
     "@typescript-eslint/parser": "4.15.1",
-    "earljs": "^0.1.10",
+    "earljs": "^0.1.12",
     "eslint": "^7.29.0",
     "eslint-config-typestrict": "^1.0.2",
     "eslint-plugin-import": "^2.23.4",

--- a/packages/hardhat-test/typechain-types/Demo.ts
+++ b/packages/hardhat-test/typechain-types/Demo.ts
@@ -6,19 +6,21 @@ import { BaseContract, BigNumber, BigNumberish, Signer, utils } from "ethers";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type Struct1Struct = { a: BigNumberish; b: BigNumberish };
+export declare namespace Demo {
+  export type Struct1Struct = { a: BigNumberish; b: BigNumberish };
 
-export type Struct1StructOutput = [BigNumber, BigNumber] & {
-  a: BigNumber;
-  b: BigNumber;
-};
+  export type Struct1StructOutput = [BigNumber, BigNumber] & {
+    a: BigNumber;
+    b: BigNumber;
+  };
 
-export type Struct2Struct = { a: BigNumberish; b: BigNumberish };
+  export type Struct2Struct = { a: BigNumberish; b: BigNumberish };
 
-export type Struct2StructOutput = [BigNumber, BigNumber] & {
-  a: BigNumber;
-  b: BigNumber;
-};
+  export type Struct2StructOutput = [BigNumber, BigNumber] & {
+    a: BigNumber;
+    b: BigNumber;
+  };
+}
 
 export interface DemoInterface extends utils.Interface {
   contractName: "Demo";

--- a/packages/hardhat-test/typechain-types/factories/Demo__factory.ts
+++ b/packages/hardhat-test/typechain-types/factories/Demo__factory.ts
@@ -3,12 +3,7 @@
 /* eslint-disable */
 import { Signer, utils, Contract, ContractFactory, Overrides } from "ethers";
 import { Provider, TransactionRequest } from "@ethersproject/providers";
-import type {
-  Demo,
-  DemoInterface,
-  Struct1Struct,
-  Struct2Struct,
-} from "../Demo";
+import type { Demo, DemoInterface } from "../Demo";
 
 const _abi = [
   {
@@ -75,15 +70,15 @@ export class Demo__factory extends ContractFactory {
   }
 
   deploy(
-    input1: Struct1Struct,
-    input2: Struct2Struct[],
+    input1: Demo.Struct1Struct,
+    input2: Demo.Struct2Struct[],
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<Demo> {
     return super.deploy(input1, input2, overrides || {}) as Promise<Demo>;
   }
   getDeployTransaction(
-    input1: Struct1Struct,
-    input2: Struct2Struct[],
+    input1: Demo.Struct1Struct,
+    input2: Demo.Struct2Struct[],
     overrides?: Overrides & { from?: string | Promise<string> }
   ): TransactionRequest {
     return super.getDeployTransaction(input1, input2, overrides || {});

--- a/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
+++ b/packages/target-ethers-v4-test/types/DataTypesInput.d.ts
@@ -38,6 +38,10 @@ interface DataTypesInputInterface extends Interface {
       encode([input1]: [BigNumberish]): string;
     }>;
 
+    input_multiple_structs_with_same_name: TypedFunctionDescription<{
+      encode([info1]: [{ a: BigNumberish; b: BigNumberish }]): string;
+    }>;
+
     input_stat_array: TypedFunctionDescription<{
       encode([input1]: [BigNumberish[]]): string;
     }>;
@@ -189,6 +193,16 @@ export class DataTypesInput extends Contract {
       input1: BigNumberish,
       overrides?: UnsignedTransaction
     ): Promise<number>;
+
+    input_multiple_structs_with_same_name(
+      info1: { a: BigNumberish; b: BigNumberish },
+      overrides?: UnsignedTransaction
+    ): Promise<[string, string] & { a: string; b: string }>;
+
+    "input_multiple_structs_with_same_name((uint160,uint160))"(
+      info1: { a: BigNumberish; b: BigNumberish },
+      overrides?: UnsignedTransaction
+    ): Promise<[string, string] & { a: string; b: string }>;
 
     input_stat_array(
       input1: BigNumberish[],
@@ -461,6 +475,16 @@ export class DataTypesInput extends Contract {
     overrides?: UnsignedTransaction
   ): Promise<number>;
 
+  input_multiple_structs_with_same_name(
+    info1: { a: BigNumberish; b: BigNumberish },
+    overrides?: UnsignedTransaction
+  ): Promise<[string, string] & { a: string; b: string }>;
+
+  "input_multiple_structs_with_same_name((uint160,uint160))"(
+    info1: { a: BigNumberish; b: BigNumberish },
+    overrides?: UnsignedTransaction
+  ): Promise<[string, string] & { a: string; b: string }>;
+
   input_stat_array(
     input1: BigNumberish[],
     overrides?: UnsignedTransaction
@@ -731,6 +755,16 @@ export class DataTypesInput extends Contract {
 
     "input_int8(int8)"(
       input1: BigNumberish,
+      overrides?: UnsignedTransaction
+    ): Promise<BigNumber>;
+
+    input_multiple_structs_with_same_name(
+      info1: { a: BigNumberish; b: BigNumberish },
+      overrides?: UnsignedTransaction
+    ): Promise<BigNumber>;
+
+    "input_multiple_structs_with_same_name((uint160,uint160))"(
+      info1: { a: BigNumberish; b: BigNumberish },
       overrides?: UnsignedTransaction
     ): Promise<BigNumber>;
 

--- a/packages/target-ethers-v4-test/types/factories/DataTypesInput__factory.ts
+++ b/packages/target-ethers-v4-test/types/factories/DataTypesInput__factory.ts
@@ -153,6 +153,49 @@ const _abi = [
   {
     inputs: [
       {
+        components: [
+          {
+            internalType: "uint160",
+            name: "a",
+            type: "uint160",
+          },
+          {
+            internalType: "uint160",
+            name: "b",
+            type: "uint160",
+          },
+        ],
+        internalType: "struct StructsLib1.Info",
+        name: "info1",
+        type: "tuple",
+      },
+    ],
+    name: "input_multiple_structs_with_same_name",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "a",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "b",
+            type: "address",
+          },
+        ],
+        internalType: "struct StructsLib2.Info",
+        name: "info2",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint8[3]",
         name: "input1",
         type: "uint8[3]",

--- a/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
@@ -257,6 +257,28 @@ describe('DataTypesInput', () => {
     })
   })
 
+  it('structs with same name in different contract/library: input test', async () => {
+    type ViewFunctionInputType = Parameters<typeof contract.input_multiple_structs_with_same_name>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type _t1 = AssertTrue<
+      IsExact<
+        ViewFunctionInputType,
+        [info1: { a: BigNumberish; b: BigNumberish }, overrides?: ethers.CallOverrides | undefined]
+      >
+    >
+
+    type ViewFunctionOutputType = Awaited<ReturnType<typeof contract.input_multiple_structs_with_same_name>>
+    type _t2 = AssertTrue<
+      IsExact<
+        ViewFunctionOutputType,
+        [string, string] & {
+          a: string
+          b: string
+        }
+      >
+    >
+  })
+
   // we skip this test as ts only about types
   it.skip('prevents from using not existing methods', () => {
     // @ts-expect-error

--- a/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
@@ -4,16 +4,15 @@ import { Awaited } from 'earljs/dist/mocks/types'
 import { BigNumber, BigNumberish, ethers } from 'ethers'
 import { AssertTrue, IsExact, q18, typedAssert } from 'test-utils'
 
-import {
-  DataTypesInput,
-  Struct1Struct,
-  Struct1StructOutput,
-  Struct2Struct,
-  Struct2StructOutput,
-  Struct3Struct,
-  Struct3StructOutput,
-} from '../types/DataTypesInput'
+import { DataTypesInput } from '../types/DataTypesInput'
 import { createNewBlockchain, deployContract } from './common'
+
+type Struct1Struct = DataTypesInput.Struct1Struct
+type Struct1StructOutput = DataTypesInput.Struct1StructOutput
+type Struct2Struct = DataTypesInput.Struct2Struct
+type Struct2StructOutput = DataTypesInput.Struct2StructOutput
+type Struct3Struct = DataTypesInput.Struct3Struct
+type Struct3StructOutput = DataTypesInput.Struct3StructOutput
 
 describe('DataTypesInput', () => {
   let contract!: DataTypesInput

--- a/packages/target-ethers-v5-test/test/Issue552Reproduction.test.ts
+++ b/packages/target-ethers-v5-test/test/Issue552Reproduction.test.ts
@@ -1,13 +1,20 @@
 import { AssertTrue, IsExact } from 'test-utils'
 
-import * as types from '../types/Issue552Reproduction'
+import { Issue552Observer, Issue552Reproduction } from '../types/Issue552Reproduction'
 import { createNewBlockchain, deployContract } from './common'
 
 describe('Issue552Reproduction', () => {
   it('does not emit overly long tuples', () => {
     type _ = [
-      AssertTrue<IsExact<types.ObservationParamsStruct['observations'], types.ObservationStruct[]>>,
-      AssertTrue<IsExact<types.ObservationParamsStructOutput['observations'], types.ObservationStructOutput[]>>,
+      AssertTrue<
+        IsExact<Issue552Reproduction.ObservationParamsStruct['observations'], Issue552Observer.ObservationStruct[]>
+      >,
+      AssertTrue<
+        IsExact<
+          Issue552Reproduction.ObservationParamsStructOutput['observations'],
+          Issue552Observer.ObservationStructOutput[]
+        >
+      >,
     ]
   })
 
@@ -15,7 +22,7 @@ describe('Issue552Reproduction', () => {
     const { signer, ganache } = await createNewBlockchain()
 
     try {
-      const contract = await deployContract<types.Issue552Reproduction>(signer, 'Issue552_Reproduction')
+      const contract = await deployContract<Issue552Reproduction>(signer, 'Issue552_Reproduction')
 
       await contract.input([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     } finally {

--- a/packages/target-ethers-v5-test/types/DataTypesInput.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesInput.ts
@@ -15,33 +15,46 @@ import { FunctionFragment, Result } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type InfoStruct = { a: BigNumberish; b: BigNumberish };
+export declare namespace StructsLib1 {
+  export type InfoStruct = { a: BigNumberish; b: BigNumberish };
 
-export type InfoStructOutput = [BigNumber, BigNumber] & {
-  a: BigNumber;
-  b: BigNumber;
-};
+  export type InfoStructOutput = [BigNumber, BigNumber] & {
+    a: BigNumber;
+    b: BigNumber;
+  };
+}
 
-export type Struct1Struct = {
-  uint256_0: BigNumberish;
-  uint256_1: BigNumberish;
-};
+export declare namespace StructsLib2 {
+  export type InfoStruct = { a: string; b: string };
 
-export type Struct1StructOutput = [BigNumber, BigNumber] & {
-  uint256_0: BigNumber;
-  uint256_1: BigNumber;
-};
+  export type InfoStructOutput = [string, string] & { a: string; b: string };
+}
 
-export type Struct2Struct = { input1: BigNumberish; input2: Struct1Struct };
+export declare namespace DataTypesInput {
+  export type Struct1Struct = {
+    uint256_0: BigNumberish;
+    uint256_1: BigNumberish;
+  };
 
-export type Struct2StructOutput = [BigNumber, Struct1StructOutput] & {
-  input1: BigNumber;
-  input2: Struct1StructOutput;
-};
+  export type Struct1StructOutput = [BigNumber, BigNumber] & {
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+  };
 
-export type Struct3Struct = { input1: BigNumberish[] };
+  export type Struct2Struct = {
+    input1: BigNumberish;
+    input2: DataTypesInput.Struct1Struct;
+  };
 
-export type Struct3StructOutput = [BigNumber[]] & { input1: BigNumber[] };
+  export type Struct2StructOutput = [
+    BigNumber,
+    DataTypesInput.Struct1StructOutput
+  ] & { input1: BigNumber; input2: DataTypesInput.Struct1StructOutput };
+
+  export type Struct3Struct = { input1: BigNumberish[] };
+
+  export type Struct3StructOutput = [BigNumber[]] & { input1: BigNumber[] };
+}
 
 export interface DataTypesInputInterface extends utils.Interface {
   contractName: "DataTypesInput";
@@ -94,7 +107,7 @@ export interface DataTypesInputInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "input_multiple_structs_with_same_name",
-    values: [InfoStruct]
+    values: [StructsLib1.InfoStruct]
   ): string;
   encodeFunctionData(
     functionFragment: "input_stat_array",
@@ -106,23 +119,29 @@ export interface DataTypesInputInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "input_struct",
-    values: [Struct1Struct]
+    values: [DataTypesInput.Struct1Struct]
   ): string;
   encodeFunctionData(
     functionFragment: "input_struct2",
-    values: [Struct2Struct]
+    values: [DataTypesInput.Struct2Struct]
   ): string;
   encodeFunctionData(
     functionFragment: "input_struct2_array",
-    values: [Struct2Struct[]]
+    values: [DataTypesInput.Struct2Struct[]]
   ): string;
   encodeFunctionData(
     functionFragment: "input_struct2_tuple",
-    values: [[Struct2Struct, Struct2Struct, Struct2Struct]]
+    values: [
+      [
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ]
+    ]
   ): string;
   encodeFunctionData(
     functionFragment: "input_struct3_array",
-    values: [Struct3Struct[]]
+    values: [DataTypesInput.Struct3Struct[]]
   ): string;
   encodeFunctionData(
     functionFragment: "input_tuple",
@@ -270,9 +289,11 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<[number]>;
 
     input_multiple_structs_with_same_name(
-      info1: InfoStruct,
+      info1: StructsLib1.InfoStruct,
       overrides?: CallOverrides
-    ): Promise<[InfoStructOutput] & { info2: InfoStructOutput }>;
+    ): Promise<
+      [StructsLib2.InfoStructOutput] & { info2: StructsLib2.InfoStructOutput }
+    >;
 
     input_stat_array(
       input1: [BigNumberish, BigNumberish, BigNumberish],
@@ -282,31 +303,41 @@ export interface DataTypesInput extends BaseContract {
     input_string(input1: string, overrides?: CallOverrides): Promise<[string]>;
 
     input_struct(
-      input1: Struct1Struct,
+      input1: DataTypesInput.Struct1Struct,
       overrides?: CallOverrides
-    ): Promise<[Struct1StructOutput]>;
+    ): Promise<[DataTypesInput.Struct1StructOutput]>;
 
     input_struct2(
-      input1: Struct2Struct,
+      input1: DataTypesInput.Struct2Struct,
       overrides?: CallOverrides
-    ): Promise<[Struct2StructOutput]>;
+    ): Promise<[DataTypesInput.Struct2StructOutput]>;
 
     input_struct2_array(
-      input1: Struct2Struct[],
+      input1: DataTypesInput.Struct2Struct[],
       overrides?: CallOverrides
-    ): Promise<[Struct2StructOutput[]]>;
+    ): Promise<[DataTypesInput.Struct2StructOutput[]]>;
 
     input_struct2_tuple(
-      input: [Struct2Struct, Struct2Struct, Struct2Struct],
+      input: [
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ],
       overrides?: CallOverrides
     ): Promise<
-      [[Struct2StructOutput, Struct2StructOutput, Struct2StructOutput]]
+      [
+        [
+          DataTypesInput.Struct2StructOutput,
+          DataTypesInput.Struct2StructOutput,
+          DataTypesInput.Struct2StructOutput
+        ]
+      ]
     >;
 
     input_struct3_array(
-      input1: Struct3Struct[],
+      input1: DataTypesInput.Struct3Struct[],
       overrides?: CallOverrides
-    ): Promise<[Struct3StructOutput[]]>;
+    ): Promise<[DataTypesInput.Struct3StructOutput[]]>;
 
     input_tuple(
       input1: BigNumberish,
@@ -348,9 +379,9 @@ export interface DataTypesInput extends BaseContract {
   input_int8(input1: BigNumberish, overrides?: CallOverrides): Promise<number>;
 
   input_multiple_structs_with_same_name(
-    info1: InfoStruct,
+    info1: StructsLib1.InfoStruct,
     overrides?: CallOverrides
-  ): Promise<InfoStructOutput>;
+  ): Promise<StructsLib2.InfoStructOutput>;
 
   input_stat_array(
     input1: [BigNumberish, BigNumberish, BigNumberish],
@@ -360,29 +391,39 @@ export interface DataTypesInput extends BaseContract {
   input_string(input1: string, overrides?: CallOverrides): Promise<string>;
 
   input_struct(
-    input1: Struct1Struct,
+    input1: DataTypesInput.Struct1Struct,
     overrides?: CallOverrides
-  ): Promise<Struct1StructOutput>;
+  ): Promise<DataTypesInput.Struct1StructOutput>;
 
   input_struct2(
-    input1: Struct2Struct,
+    input1: DataTypesInput.Struct2Struct,
     overrides?: CallOverrides
-  ): Promise<Struct2StructOutput>;
+  ): Promise<DataTypesInput.Struct2StructOutput>;
 
   input_struct2_array(
-    input1: Struct2Struct[],
+    input1: DataTypesInput.Struct2Struct[],
     overrides?: CallOverrides
-  ): Promise<Struct2StructOutput[]>;
+  ): Promise<DataTypesInput.Struct2StructOutput[]>;
 
   input_struct2_tuple(
-    input: [Struct2Struct, Struct2Struct, Struct2Struct],
+    input: [
+      DataTypesInput.Struct2Struct,
+      DataTypesInput.Struct2Struct,
+      DataTypesInput.Struct2Struct
+    ],
     overrides?: CallOverrides
-  ): Promise<[Struct2StructOutput, Struct2StructOutput, Struct2StructOutput]>;
+  ): Promise<
+    [
+      DataTypesInput.Struct2StructOutput,
+      DataTypesInput.Struct2StructOutput,
+      DataTypesInput.Struct2StructOutput
+    ]
+  >;
 
   input_struct3_array(
-    input1: Struct3Struct[],
+    input1: DataTypesInput.Struct3Struct[],
     overrides?: CallOverrides
-  ): Promise<Struct3StructOutput[]>;
+  ): Promise<DataTypesInput.Struct3StructOutput[]>;
 
   input_tuple(
     input1: BigNumberish,
@@ -427,9 +468,9 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<number>;
 
     input_multiple_structs_with_same_name(
-      info1: InfoStruct,
+      info1: StructsLib1.InfoStruct,
       overrides?: CallOverrides
-    ): Promise<InfoStructOutput>;
+    ): Promise<StructsLib2.InfoStructOutput>;
 
     input_stat_array(
       input1: [BigNumberish, BigNumberish, BigNumberish],
@@ -439,29 +480,39 @@ export interface DataTypesInput extends BaseContract {
     input_string(input1: string, overrides?: CallOverrides): Promise<string>;
 
     input_struct(
-      input1: Struct1Struct,
+      input1: DataTypesInput.Struct1Struct,
       overrides?: CallOverrides
-    ): Promise<Struct1StructOutput>;
+    ): Promise<DataTypesInput.Struct1StructOutput>;
 
     input_struct2(
-      input1: Struct2Struct,
+      input1: DataTypesInput.Struct2Struct,
       overrides?: CallOverrides
-    ): Promise<Struct2StructOutput>;
+    ): Promise<DataTypesInput.Struct2StructOutput>;
 
     input_struct2_array(
-      input1: Struct2Struct[],
+      input1: DataTypesInput.Struct2Struct[],
       overrides?: CallOverrides
-    ): Promise<Struct2StructOutput[]>;
+    ): Promise<DataTypesInput.Struct2StructOutput[]>;
 
     input_struct2_tuple(
-      input: [Struct2Struct, Struct2Struct, Struct2Struct],
+      input: [
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ],
       overrides?: CallOverrides
-    ): Promise<[Struct2StructOutput, Struct2StructOutput, Struct2StructOutput]>;
+    ): Promise<
+      [
+        DataTypesInput.Struct2StructOutput,
+        DataTypesInput.Struct2StructOutput,
+        DataTypesInput.Struct2StructOutput
+      ]
+    >;
 
     input_struct3_array(
-      input1: Struct3Struct[],
+      input1: DataTypesInput.Struct3Struct[],
       overrides?: CallOverrides
-    ): Promise<Struct3StructOutput[]>;
+    ): Promise<DataTypesInput.Struct3StructOutput[]>;
 
     input_tuple(
       input1: BigNumberish,
@@ -521,7 +572,7 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<BigNumber>;
 
     input_multiple_structs_with_same_name(
-      info1: InfoStruct,
+      info1: StructsLib1.InfoStruct,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -533,27 +584,31 @@ export interface DataTypesInput extends BaseContract {
     input_string(input1: string, overrides?: CallOverrides): Promise<BigNumber>;
 
     input_struct(
-      input1: Struct1Struct,
+      input1: DataTypesInput.Struct1Struct,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     input_struct2(
-      input1: Struct2Struct,
+      input1: DataTypesInput.Struct2Struct,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     input_struct2_array(
-      input1: Struct2Struct[],
+      input1: DataTypesInput.Struct2Struct[],
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     input_struct2_tuple(
-      input: [Struct2Struct, Struct2Struct, Struct2Struct],
+      input: [
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ],
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     input_struct3_array(
-      input1: Struct3Struct[],
+      input1: DataTypesInput.Struct3Struct[],
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -616,7 +671,7 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     input_multiple_structs_with_same_name(
-      info1: InfoStruct,
+      info1: StructsLib1.InfoStruct,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
@@ -631,27 +686,31 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     input_struct(
-      input1: Struct1Struct,
+      input1: DataTypesInput.Struct1Struct,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     input_struct2(
-      input1: Struct2Struct,
+      input1: DataTypesInput.Struct2Struct,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     input_struct2_array(
-      input1: Struct2Struct[],
+      input1: DataTypesInput.Struct2Struct[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     input_struct2_tuple(
-      input: [Struct2Struct, Struct2Struct, Struct2Struct],
+      input: [
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     input_struct3_array(
-      input1: Struct3Struct[],
+      input1: DataTypesInput.Struct3Struct[],
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 

--- a/packages/target-ethers-v5-test/types/DataTypesInput.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesInput.ts
@@ -15,6 +15,13 @@ import { FunctionFragment, Result } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
+export type InfoStruct = { a: BigNumberish; b: BigNumberish };
+
+export type InfoStructOutput = [BigNumber, BigNumber] & {
+  a: BigNumber;
+  b: BigNumber;
+};
+
 export type Struct1Struct = {
   uint256_0: BigNumberish;
   uint256_1: BigNumberish;
@@ -46,6 +53,7 @@ export interface DataTypesInputInterface extends utils.Interface {
     "input_enum(uint8)": FunctionFragment;
     "input_int256(int256)": FunctionFragment;
     "input_int8(int8)": FunctionFragment;
+    "input_multiple_structs_with_same_name((uint160,uint160))": FunctionFragment;
     "input_stat_array(uint8[3])": FunctionFragment;
     "input_string(string)": FunctionFragment;
     "input_struct((uint256,uint256))": FunctionFragment;
@@ -83,6 +91,10 @@ export interface DataTypesInputInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "input_int8",
     values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "input_multiple_structs_with_same_name",
+    values: [InfoStruct]
   ): string;
   encodeFunctionData(
     functionFragment: "input_stat_array",
@@ -148,6 +160,10 @@ export interface DataTypesInputInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "input_int8", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "input_multiple_structs_with_same_name",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "input_stat_array",
     data: BytesLike
@@ -253,6 +269,11 @@ export interface DataTypesInput extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[number]>;
 
+    input_multiple_structs_with_same_name(
+      info1: InfoStruct,
+      overrides?: CallOverrides
+    ): Promise<[InfoStructOutput] & { info2: InfoStructOutput }>;
+
     input_stat_array(
       input1: [BigNumberish, BigNumberish, BigNumberish],
       overrides?: CallOverrides
@@ -325,6 +346,11 @@ export interface DataTypesInput extends BaseContract {
   ): Promise<BigNumber>;
 
   input_int8(input1: BigNumberish, overrides?: CallOverrides): Promise<number>;
+
+  input_multiple_structs_with_same_name(
+    info1: InfoStruct,
+    overrides?: CallOverrides
+  ): Promise<InfoStructOutput>;
 
   input_stat_array(
     input1: [BigNumberish, BigNumberish, BigNumberish],
@@ -399,6 +425,11 @@ export interface DataTypesInput extends BaseContract {
       input1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<number>;
+
+    input_multiple_structs_with_same_name(
+      info1: InfoStruct,
+      overrides?: CallOverrides
+    ): Promise<InfoStructOutput>;
 
     input_stat_array(
       input1: [BigNumberish, BigNumberish, BigNumberish],
@@ -489,6 +520,11 @@ export interface DataTypesInput extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    input_multiple_structs_with_same_name(
+      info1: InfoStruct,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     input_stat_array(
       input1: [BigNumberish, BigNumberish, BigNumberish],
       overrides?: CallOverrides
@@ -576,6 +612,11 @@ export interface DataTypesInput extends BaseContract {
 
     input_int8(
       input1: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    input_multiple_structs_with_same_name(
+      info1: InfoStruct,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 

--- a/packages/target-ethers-v5-test/types/DataTypesPure.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesPure.ts
@@ -15,15 +15,17 @@ import { FunctionFragment, Result } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type Struct1Struct = {
-  uint256_0: BigNumberish;
-  uint256_1: BigNumberish;
-};
+export declare namespace DataTypesPure {
+  export type Struct1Struct = {
+    uint256_0: BigNumberish;
+    uint256_1: BigNumberish;
+  };
 
-export type Struct1StructOutput = [BigNumber, BigNumber] & {
-  uint256_0: BigNumber;
-  uint256_1: BigNumber;
-};
+  export type Struct1StructOutput = [BigNumber, BigNumber] & {
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+  };
+}
 
 export interface DataTypesPureInterface extends utils.Interface {
   contractName: "DataTypesPure";
@@ -185,7 +187,9 @@ export interface DataTypesPure extends BaseContract {
 
     pure_string(overrides?: CallOverrides): Promise<[string]>;
 
-    pure_struct(overrides?: CallOverrides): Promise<[Struct1StructOutput]>;
+    pure_struct(
+      overrides?: CallOverrides
+    ): Promise<[DataTypesPure.Struct1StructOutput]>;
 
     pure_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 
@@ -218,7 +222,9 @@ export interface DataTypesPure extends BaseContract {
 
   pure_string(overrides?: CallOverrides): Promise<string>;
 
-  pure_struct(overrides?: CallOverrides): Promise<Struct1StructOutput>;
+  pure_struct(
+    overrides?: CallOverrides
+  ): Promise<DataTypesPure.Struct1StructOutput>;
 
   pure_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 
@@ -253,7 +259,9 @@ export interface DataTypesPure extends BaseContract {
 
     pure_string(overrides?: CallOverrides): Promise<string>;
 
-    pure_struct(overrides?: CallOverrides): Promise<Struct1StructOutput>;
+    pure_struct(
+      overrides?: CallOverrides
+    ): Promise<DataTypesPure.Struct1StructOutput>;
 
     pure_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 

--- a/packages/target-ethers-v5-test/types/DataTypesView.ts
+++ b/packages/target-ethers-v5-test/types/DataTypesView.ts
@@ -15,15 +15,17 @@ import { FunctionFragment, Result } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type Struct1Struct = {
-  uint256_0: BigNumberish;
-  uint256_1: BigNumberish;
-};
+export declare namespace DataTypesView {
+  export type Struct1Struct = {
+    uint256_0: BigNumberish;
+    uint256_1: BigNumberish;
+  };
 
-export type Struct1StructOutput = [BigNumber, BigNumber] & {
-  uint256_0: BigNumber;
-  uint256_1: BigNumber;
-};
+  export type Struct1StructOutput = [BigNumber, BigNumber] & {
+    uint256_0: BigNumber;
+    uint256_1: BigNumber;
+  };
+}
 
 export interface DataTypesViewInterface extends utils.Interface {
   contractName: "DataTypesView";
@@ -185,7 +187,9 @@ export interface DataTypesView extends BaseContract {
 
     view_string(overrides?: CallOverrides): Promise<[string]>;
 
-    view_struct(overrides?: CallOverrides): Promise<[Struct1StructOutput]>;
+    view_struct(
+      overrides?: CallOverrides
+    ): Promise<[DataTypesView.Struct1StructOutput]>;
 
     view_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 
@@ -218,7 +222,9 @@ export interface DataTypesView extends BaseContract {
 
   view_string(overrides?: CallOverrides): Promise<string>;
 
-  view_struct(overrides?: CallOverrides): Promise<Struct1StructOutput>;
+  view_struct(
+    overrides?: CallOverrides
+  ): Promise<DataTypesView.Struct1StructOutput>;
 
   view_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 
@@ -253,7 +259,9 @@ export interface DataTypesView extends BaseContract {
 
     view_string(overrides?: CallOverrides): Promise<string>;
 
-    view_struct(overrides?: CallOverrides): Promise<Struct1StructOutput>;
+    view_struct(
+      overrides?: CallOverrides
+    ): Promise<DataTypesView.Struct1StructOutput>;
 
     view_tuple(overrides?: CallOverrides): Promise<[BigNumber, BigNumber]>;
 

--- a/packages/target-ethers-v5-test/types/Events.ts
+++ b/packages/target-ethers-v5-test/types/Events.ts
@@ -17,12 +17,14 @@ import { FunctionFragment, Result, EventFragment } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type EventDataStruct = { index: BigNumberish; name: string };
+export declare namespace Events {
+  export type EventDataStruct = { index: BigNumberish; name: string };
 
-export type EventDataStructOutput = [BigNumber, string] & {
-  index: BigNumber;
-  name: string;
-};
+  export type EventDataStructOutput = [BigNumber, string] & {
+    index: BigNumber;
+    name: string;
+  };
+}
 
 export interface EventsInterface extends utils.Interface {
   contractName: "Events";
@@ -133,8 +135,8 @@ export type Event3_uint256_Event = TypedEvent<
 export type Event3_uint256_EventFilter = TypedEventFilter<Event3_uint256_Event>;
 
 export type Event4Event = TypedEvent<
-  [EventDataStructOutput],
-  { data: EventDataStructOutput }
+  [Events.EventDataStructOutput],
+  { data: Events.EventDataStructOutput }
 >;
 
 export type Event4EventFilter = TypedEventFilter<Event4Event>;

--- a/packages/target-ethers-v5-test/types/Issue552Reproduction.ts
+++ b/packages/target-ethers-v5-test/types/Issue552Reproduction.ts
@@ -17,25 +17,32 @@ import { FunctionFragment, Result } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type ObservationStruct = {
-  val: BigNumberish;
-  blockTimestamp: BigNumberish;
-};
+export declare namespace Issue552Observer {
+  export type ObservationStruct = {
+    val: BigNumberish;
+    blockTimestamp: BigNumberish;
+  };
 
-export type ObservationStructOutput = [BigNumber, BigNumber] & {
-  val: BigNumber;
-  blockTimestamp: BigNumber;
-};
+  export type ObservationStructOutput = [BigNumber, BigNumber] & {
+    val: BigNumber;
+    blockTimestamp: BigNumber;
+  };
+}
 
-export type ObservationParamsStruct = {
-  observations: ObservationStruct[];
-  index: BigNumberish;
-};
+export declare namespace Issue552Reproduction {
+  export type ObservationParamsStruct = {
+    observations: Issue552Observer.ObservationStruct[];
+    index: BigNumberish;
+  };
 
-export type ObservationParamsStructOutput = [
-  ObservationStructOutput[],
-  number
-] & { observations: ObservationStructOutput[]; index: number };
+  export type ObservationParamsStructOutput = [
+    Issue552Observer.ObservationStructOutput[],
+    number
+  ] & {
+    observations: Issue552Observer.ObservationStructOutput[];
+    index: number;
+  };
+}
 
 export interface Issue552ReproductionInterface extends utils.Interface {
   contractName: "Issue552Reproduction";
@@ -97,8 +104,8 @@ export interface Issue552Reproduction extends BaseContract {
       arg0: BigNumberish,
       overrides?: CallOverrides
     ): Promise<
-      [ObservationParamsStructOutput] & {
-        fooObservations: ObservationParamsStructOutput;
+      [Issue552Reproduction.ObservationParamsStructOutput] & {
+        fooObservations: Issue552Reproduction.ObservationParamsStructOutput;
       }
     >;
 
@@ -114,7 +121,7 @@ export interface Issue552Reproduction extends BaseContract {
   bars(
     arg0: BigNumberish,
     overrides?: CallOverrides
-  ): Promise<ObservationParamsStructOutput>;
+  ): Promise<Issue552Reproduction.ObservationParamsStructOutput>;
 
   input(values: BigNumberish[], overrides?: CallOverrides): Promise<void>;
 
@@ -128,7 +135,7 @@ export interface Issue552Reproduction extends BaseContract {
     bars(
       arg0: BigNumberish,
       overrides?: CallOverrides
-    ): Promise<ObservationParamsStructOutput>;
+    ): Promise<Issue552Reproduction.ObservationParamsStructOutput>;
 
     input(values: BigNumberish[], overrides?: CallOverrides): Promise<void>;
 

--- a/packages/target-ethers-v5-test/types/KingOfTheHill.ts
+++ b/packages/target-ethers-v5-test/types/KingOfTheHill.ts
@@ -18,12 +18,14 @@ import { FunctionFragment, Result, EventFragment } from "@ethersproject/abi";
 import { Listener, Provider } from "@ethersproject/providers";
 import { TypedEventFilter, TypedEvent, TypedListener, OnEvent } from "./common";
 
-export type BidStruct = { bidder: string; value: BigNumberish };
+export declare namespace KingOfTheHill {
+  export type BidStruct = { bidder: string; value: BigNumberish };
 
-export type BidStructOutput = [string, BigNumber] & {
-  bidder: string;
-  value: BigNumber;
-};
+  export type BidStructOutput = [string, BigNumber] & {
+    bidder: string;
+    value: BigNumber;
+  };
+}
 
 export interface KingOfTheHillInterface extends utils.Interface {
   contractName: "KingOfTheHill";
@@ -52,8 +54,8 @@ export interface KingOfTheHillInterface extends utils.Interface {
 }
 
 export type HighestBidIncreasedEvent = TypedEvent<
-  [BidStructOutput],
-  { bid: BidStructOutput }
+  [KingOfTheHill.BidStructOutput],
+  { bid: KingOfTheHill.BidStructOutput }
 >;
 
 export type HighestBidIncreasedEventFilter = TypedEventFilter<

--- a/packages/target-ethers-v5-test/types/factories/DataTypesInput__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/DataTypesInput__factory.ts
@@ -146,6 +146,49 @@ const _abi = [
   {
     inputs: [
       {
+        components: [
+          {
+            internalType: "uint160",
+            name: "a",
+            type: "uint160",
+          },
+          {
+            internalType: "uint160",
+            name: "b",
+            type: "uint160",
+          },
+        ],
+        internalType: "struct StructsLib1.Info",
+        name: "info1",
+        type: "tuple",
+      },
+    ],
+    name: "input_multiple_structs_with_same_name",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "a",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "b",
+            type: "address",
+          },
+        ],
+        internalType: "struct StructsLib2.Info",
+        name: "info2",
+        type: "tuple",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint8[3]",
         name: "input1",
         type: "uint8[3]",

--- a/packages/target-ethers-v5/src/codegen/structs.ts
+++ b/packages/target-ethers-v5/src/codegen/structs.ts
@@ -1,16 +1,42 @@
-import { StructType } from 'typechain'
+import { groupBy } from 'lodash'
+import { StructName, StructType } from 'typechain'
 
 import { STRUCT_INPUT_POSTFIX, STRUCT_OUTPUT_POSTFIX } from '../common'
 import { generateInputType, generateOutputType } from './types'
 
-export function generateStruct(struct: StructType): string {
-  if (struct.structName) {
-    return `
-      export type ${struct.structName + STRUCT_INPUT_POSTFIX} = ${generateInputType({ useStructs: false }, struct)}
-      
-      export type ${struct.structName + STRUCT_OUTPUT_POSTFIX} = ${generateOutputType({ useStructs: false }, struct)}
-      `
-  } else {
-    return ''
+export function generateStructTypes(structs: StructType[]) {
+  const namedStructs = structs.filter((s): s is StructWithName => !!s.structName)
+  const namespaces = groupBy(namedStructs, (s) => s.structName.namespace)
+
+  const exports: string[] = []
+
+  if ('undefined' in namespaces) {
+    exports.push(namespaces['undefined'].map((s) => generateExports(s)).join('\n'))
+    delete namespaces['undefined']
   }
+
+  for (const namespace of Object.keys(namespaces)) {
+    exports.push(`\nexport declare namespace ${namespace} {
+      ${namespaces[namespace].map((s) => generateExports(s)).join('\n')}
+    }`)
+  }
+
+  return exports.join('\n')
 }
+
+function generateExports(struct: StructWithName): string {
+  const { identifier } = struct.structName
+
+  const inputName = `${identifier}${STRUCT_INPUT_POSTFIX}`
+  const outputName = `${identifier}${STRUCT_OUTPUT_POSTFIX}`
+  const inputType = generateInputType({ useStructs: false }, struct)
+  const outputType = generateOutputType({ useStructs: false }, struct)
+
+  return `
+    export type ${inputName} = ${inputType}
+
+    export type ${outputName} = ${outputType}
+  `
+}
+
+type StructWithName = StructType & { structName: StructName }

--- a/packages/target-ethers-v5/src/codegen/types.ts
+++ b/packages/target-ethers-v5/src/codegen/types.ts
@@ -47,7 +47,7 @@ export function generateInputType(options: GenerateTypeOptions, evmType: EvmType
       } else {
         return generateArrayOrTupleType(
           evmType.structName
-            ? evmType.structName + STRUCT_INPUT_POSTFIX
+            ? evmType.structName.toString() + STRUCT_INPUT_POSTFIX
             : generateInputType({ ...options, useStructs: true }, evmType.itemType),
           evmType.size,
         )
@@ -58,7 +58,7 @@ export function generateInputType(options: GenerateTypeOptions, evmType: EvmType
       return 'string'
     case 'tuple':
       if (evmType.structName && options.useStructs) {
-        return evmType.structName + STRUCT_INPUT_POSTFIX
+        return evmType.structName.toString() + STRUCT_INPUT_POSTFIX
       }
       return generateObjectTypeLiteral(evmType, generateInputType.bind(null, { ...options, useStructs: true }))
     case 'unknown':
@@ -86,7 +86,7 @@ export function generateOutputType(options: GenerateTypeOptions, evmType: EvmOut
       }
       return generateArrayOrTupleType(
         evmType.structName
-          ? evmType.structName + STRUCT_OUTPUT_POSTFIX
+          ? evmType.structName.toString() + STRUCT_OUTPUT_POSTFIX
           : generateOutputType({ ...options, useStructs: true }, evmType.itemType),
         evmType.size,
       )
@@ -96,7 +96,7 @@ export function generateOutputType(options: GenerateTypeOptions, evmType: EvmOut
       return 'string'
     case 'tuple':
       if (evmType.structName && options.useStructs) {
-        return evmType.structName + STRUCT_OUTPUT_POSTFIX
+        return evmType.structName.toString() + STRUCT_OUTPUT_POSTFIX
       }
       return generateOutputComplexType(evmType.components, { ...options, useStructs: true })
     case 'unknown':
@@ -105,7 +105,7 @@ export function generateOutputType(options: GenerateTypeOptions, evmType: EvmOut
 }
 
 export function generateObjectTypeLiteral(tuple: TupleType, generator: (evmType: EvmType) => string) {
-  return '{' + tuple.components.map((component) => `${component.name}: ${generator(component.type)}`).join(',') + '}'
+  return '{' + tuple.components.map((component) => `${component.name}: ${generator(component.type)}`).join(', ') + '}'
 }
 
 /**
@@ -135,7 +135,7 @@ export function generateOutputComplexTypesAsObject(
   const namedElements = components.filter((e) => !!e.name)
   if (namedElements.length > 0) {
     namedElementsCode =
-      '{' + namedElements.map((t) => `${t.name}: ${generateOutputType(options, t.type)}`).join(',') + ' }'
+      '{' + namedElements.map((t) => `${t.name}: ${generateOutputType(options, t.type)}`).join(', ') + ' }'
   }
 
   return namedElementsCode

--- a/packages/target-ethers-v5/test/structs.test.ts
+++ b/packages/target-ethers-v5/test/structs.test.ts
@@ -1,0 +1,60 @@
+import { expect } from 'earljs'
+import { format } from 'prettier'
+import { StructName } from 'typechain'
+
+import { generateStructTypes } from '../src/codegen/structs'
+
+const prettier = (s: string) => format(s, { parser: 'typescript' })
+
+describe(generateStructTypes.name, () => {
+  it('generates export declarations for top level and namespaced structs', () => {
+    const actual = generateStructTypes([
+      {
+        type: 'array',
+        itemType: {
+          type: 'array',
+          itemType: {
+            type: 'tuple',
+            components: [
+              { name: 'target', type: { type: 'address', originalType: 'address' } },
+              { name: 'callData', type: { type: 'dynamic-bytes', originalType: 'bytes' } },
+            ],
+            originalType: 'tuple',
+          },
+          originalType: 'tuple[]',
+        },
+        originalType: 'tuple[][]',
+        structName: new StructName('Call', 'Multicall'),
+      },
+      {
+        structName: new StructName('Vector2'),
+        type: 'array',
+        originalType: 'tuple[2]',
+        size: 2,
+        itemType: {
+          type: 'tuple',
+          originalType: 'tuple',
+          components: [
+            { name: 'x', type: { originalType: 'uint256', type: 'uinteger', bits: 256 } },
+            { name: 'y', type: { originalType: 'uint256', type: 'uinteger', bits: 256 } },
+          ],
+        },
+      },
+    ])
+
+    expect(prettier(actual)).toEqual(
+      prettier(
+        `
+        export type Vector2Struct = { x: BigNumberish, y: BigNumberish }
+
+        export type Vector2StructOutput = [BigNumber, BigNumber] & { x: BigNumber, y: BigNumber }
+
+        export declare namespace Multicall {
+          export type CallStruct = { target: string, callData: BytesLike }[]
+
+          export type CallStructOutput = ([string, string] & { target: string, callData: string })[]
+        }`,
+      ),
+    )
+  })
+})

--- a/packages/target-truffle-v5-test/types/truffle-contracts/DataTypesInput.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/DataTypesInput.d.ts
@@ -125,6 +125,11 @@ export interface DataTypesInputInstance extends Truffle.ContractInstance {
     txDetails?: Truffle.TransactionDetails
   ): Promise<{ input1: BN; input2: { uint256_0: BN; uint256_1: BN } }[]>;
 
+  input_multiple_structs_with_same_name(
+    info1: { a: number | BN | string; b: number | BN | string },
+    txDetails?: Truffle.TransactionDetails
+  ): Promise<{ a: string; b: string }>;
+
   methods: {
     input_uint8(
       input1: number | BN | string,
@@ -237,6 +242,11 @@ export interface DataTypesInputInstance extends Truffle.ContractInstance {
       }[],
       txDetails?: Truffle.TransactionDetails
     ): Promise<{ input1: BN; input2: { uint256_0: BN; uint256_1: BN } }[]>;
+
+    input_multiple_structs_with_same_name(
+      info1: { a: number | BN | string; b: number | BN | string },
+      txDetails?: Truffle.TransactionDetails
+    ): Promise<{ a: string; b: string }>;
   };
 
   getPastEvents(event: string): Promise<EventData[]>;

--- a/packages/target-web3-v1-test/types/DataTypesInput.ts
+++ b/packages/target-web3-v1-test/types/DataTypesInput.ts
@@ -51,6 +51,10 @@ export interface DataTypesInput extends BaseContract {
       input1: number | string | BN
     ): NonPayableTransactionObject<string>;
 
+    input_multiple_structs_with_same_name(
+      info1: [number | string | BN, number | string | BN]
+    ): NonPayableTransactionObject<[string, string]>;
+
     input_stat_array(
       input1: (number | string | BN)[]
     ): NonPayableTransactionObject<string[]>;

--- a/packages/typechain/src/parser/abiParser.ts
+++ b/packages/typechain/src/parser/abiParser.ts
@@ -140,7 +140,8 @@ export function parse(abi: RawAbiDefinition[], rawName: string, documentation?: 
 
   const structs: StructType[] = []
   function registerStruct(newStruct: StructType) {
-    if (structs.findIndex((s) => s.structName === newStruct.structName) === -1) {
+    const newStructName = newStruct.structName?.toString()
+    if (!structs.find((s) => s.structName?.toString() === newStructName)) {
       structs.push(newStruct)
     }
   }
@@ -185,7 +186,7 @@ export function parse(abi: RawAbiDefinition[], rawName: string, documentation?: 
     constructor: constructors,
     functions: groupBy(functions, (f) => f.name),
     events: groupBy(events, (e) => e.name),
-    structs: groupBy(structs, (e) => e.structName),
+    structs: groupBy(structs, (e) => e.structName && e.structName.toString()),
     documentation: documentation ? omit(documentation, ['methods']) : undefined,
   }
 }
@@ -323,7 +324,9 @@ function parseRawAbiParameterType(
       // We unwrap constant size struct arrays like `Item[4]` into `Item`.
       registerStruct({
         ...parsed.itemType,
-        structName: parsed.structName.replace(new RegExp(`\\[${parsed.size}\\]$`), ''),
+        structName: parsed.structName.merge({
+          identifier: parsed.structName.identifier.replace(new RegExp(`\\[${parsed.size}\\]$`), ''),
+        }),
       })
     } else {
       registerStruct(parsed)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6579,10 +6579,10 @@ duplexify@^3.2.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earljs@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/earljs/-/earljs-0.1.10.tgz#4d587885c8e13cbd3a298ea40796ea580daece69"
-  integrity sha512-3/tIKsL5ryPWgjHFue99ljXeHCMVEvJZTkhnmaMM4kRb8F94dxxatZgXRrwmf5ohQruJU330JvYVYwnw96bzrw==
+earljs@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/earljs/-/earljs-0.1.12.tgz#92437d349dfc580e49adc24c76ecdad0b222d7b0"
+  integrity sha512-qTuYVJgbGdb1syLeQ/mD/SIm914TGI9kxzVrXQ3a03lzFQsKP202tqsdBFqU9d+J8k7fM41eglmLvzKGt0FJhw==
   dependencies:
     debug "^4.1.1"
     jest-snapshot "^26.6.2"


### PR DESCRIPTION
```solidity
contract MyContract
  function input_multiple_structs_with_same_name(StructsLib1.Info memory info1) public pure returns (StructsLib2.Info memory info2) {
     info2.a = address(info1.a);
     info2.b = address(info1.b);
   }
 }

 library StructsLib1 {
   struct Info {
     uint160 a;
     uint160 b;
   }
 }

 library StructsLib2 {
   struct Info {
     address a;
     address b;
   }
 }
```

Generated Typings:

```typescript
export type InfoStruct = { a: BigNumberish; b: BigNumberish };

export type InfoStructOutput = [BigNumber, BigNumber] & {
  a: BigNumber;
  b: BigNumber;
};


input_multiple_structs_with_same_name(
  info1: InfoStruct,
  overrides?: CallOverrides
): Promise<InfoStructOutput>;
```

---

Closes #574 