### PR TITLE
update internal task name to match hardhat convention

### DIFF
--- a/.changeset/rich-penguins-shave.md
+++ b/.changeset/rich-penguins-shave.md
@@ -1,0 +1,5 @@
+---
+"@typechain/hardhat": major
+---
+
+Update internal task name to match hardhat convention

--- a/packages/hardhat/src/constants.ts
+++ b/packages/hardhat/src/constants.ts
@@ -1,2 +1,2 @@
 export const TASK_TYPECHAIN: string = 'typechain'
-export const TASK_TYPECHAIN_GENERATE_TYPES: string = 'typechain-generate-types'
+export const TASK_TYPECHAIN_GENERATE_TYPES: string = 'typechain:generate-types'


### PR DESCRIPTION
The Hardhat internal tasks use colons rather than hyphens to simulate task namespaces: https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/builtin-tasks/task-names.ts.  TypeChain should do the same.  Change should not be considered breaking because the proper way to reference a task name is by importing `constants.ts`.