### PR TITLE
Update abiParser.ts to work with foundry / forge output + Tests

### DIFF
--- a/.changeset/four-carrots-collect.md
+++ b/.changeset/four-carrots-collect.md
@@ -1,0 +1,5 @@
+---
+"typechain": patch
+---
+
+Add support for foundry / forge style artifacts

--- a/packages/typechain/src/parser/abiParser.ts
+++ b/packages/typechain/src/parser/abiParser.ts
@@ -396,6 +396,11 @@ export function extractBytecode(rawContents: string): BytecodeWithLinkReferences
     )
   }
 
+  // handle json schema of @foundry/forge
+  if (json.bytecode?.object?.match(bytecodeRegex)) {
+    return extractLinkReferences(json.bytecode.object, json.bytecode.linkReferences)
+  }
+
   if (json.bytecode?.match(bytecodeRegex)) {
     return extractLinkReferences(json.bytecode, json.linkReferences)
   }

--- a/packages/typechain/test/parser/abiParser.test.ts
+++ b/packages/typechain/test/parser/abiParser.test.ts
@@ -140,6 +140,10 @@ describe('extractBytecode', () => {
     ).toEqual(resultBytecode)
   })
 
+  it('should return bytecode from nested abi (@foundry/forge style)', () => {
+    expect(extractBytecode(`{ "bytecode": { "object": "${sampleBytecode}" } }`)).toEqual(resultBytecode)
+  })
+
   it('should return undefined when nested abi bytecode is malformed', () => {
     expect(extractBytecode(`{ "bytecode": "surely-not-bytecode" }`)).toEqual(undefined)
   })


### PR DESCRIPTION
Adds tests to @joeandrews' PR (https://github.com/dethcrypto/TypeChain/pull/618) and applies his change.

From @joeandrews' PR:
Forge / Foundry structures ABI's as below. This change makes the ABI parser compatible with the output from forge.
```
{
  "abi": [],
  "bytecode": {
    "object": "0x60566037600b82828239805160001a607314602a57634e487b7160e01b600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212205bf70e5aa6eb164145ba1ab154b06c77bba3192b4507a03c711393334ab8aafb64736f6c634300080a0033",
    "sourceMap": "153:195:3:-:0;;;;;;;;;;;;;;;-1:-1:-1;;;153:195:3;;;;;;;;;;;;;;;;;",
    "linkReferences": {}
  },
  "deployed_bytecode": {
    "object": "0x73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212205bf70e5aa6eb164145ba1ab154b06c77bba3192b4507a03c711393334ab8aafb64736f6c634300080a0033",
    "sourceMap": "153:195:3:-:0;;;;;;;;",
    "linkReferences": {}
  }
}
```