### PR TITLE
Fix sample tsconfig.json excerpt in README.md

### DIFF
--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -57,7 +57,7 @@ Here's a sample `tsconfig.json`:
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["./scripts", "./test", "./typechain"],
+  "include": ["./scripts", "./test", "./typechain-types"],
   "files": ["./hardhat.config.ts"]
 }
 ```


### PR DESCRIPTION
Since newer versions of typechain default to `./typechain-types` for the type outputs I think the README should match the default as it easily confuses new users.