### PR TITLE
Fix interface overloads in ethers-v5 target

### DIFF
--- a/packages/target-ethers-v5/src/codegen/events.ts
+++ b/packages/target-ethers-v5/src/codegen/events.ts
@@ -74,8 +74,8 @@ export function generateEventArgType(eventArg: EventArgDeclaration): string {
   return eventArg.isIndexed ? `${generateInputType({ useStructs: true }, eventArg.type)} | null` : 'null'
 }
 
-export function generateGetEventOverload(event: EventDeclaration): string {
-  return `getEvent(nameOrSignatureOrTopic: '${event.name}'): EventFragment;`
+export function generateGetEvent(event: EventDeclaration, useSignature: boolean): string {
+  return `getEvent(nameOrSignatureOrTopic: '${useSignature ? generateEventSignature(event) : event.name}'): EventFragment;`
 }
 
 function generateEventIdentifier(event: EventDeclaration, { includeArgTypes }: { includeArgTypes?: boolean } = {}) {

--- a/packages/target-ethers-v5/src/codegen/functions.ts
+++ b/packages/target-ethers-v5/src/codegen/functions.ts
@@ -86,8 +86,13 @@ export function generateInterfaceFunctionDescription(fn: FunctionDeclaration): s
   return `'${getSignatureForFn(fn)}': FunctionFragment;`
 }
 
-export function generateEncodeFunctionDataOverload(fn: FunctionDeclaration): string {
-  const methodInputs = [`functionFragment: '${fn.name}'`]
+
+export function generateGetFunction(fn: FunctionDeclaration, useSignature: boolean): string {
+  return `getFunction(nameOrSignatureOrTopic: '${useSignature ? getSignatureForFn(fn) : fn.name}'): FunctionFragment;`
+}
+
+export function generateEncodeFunctionDataOverload(fn: FunctionDeclaration, useSignature: boolean): string {
+  const methodInputs = [`functionFragment: '${useSignature ? getSignatureForFn(fn) : fn.name}'`]
 
   if (fn.inputs.length) {
     methodInputs.push(
@@ -100,8 +105,8 @@ export function generateEncodeFunctionDataOverload(fn: FunctionDeclaration): str
   return `encodeFunctionData(${methodInputs.join(', ')}): string;`
 }
 
-export function generateDecodeFunctionResultOverload(fn: FunctionDeclaration): string {
-  return `decodeFunctionResult(functionFragment: '${fn.name}', data: BytesLike): Result;`
+export function generateDecodeFunctionResultOverload(fn: FunctionDeclaration, useSignature: boolean): string {
+  return `decodeFunctionResult(functionFragment: '${useSignature ? getSignatureForFn(fn) : fn.name}', data: BytesLike): Result;`
 }
 
 export function generateParamNames(params: Array<AbiParameter | EventArgDeclaration>): string {

--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -5,6 +5,8 @@ import {
   Contract,
   createImportsForUsedIdentifiers,
   createImportTypeDeclaration,
+  EventDeclaration,
+  FunctionDeclaration,
   StructType,
 } from 'typechain'
 
@@ -14,13 +16,14 @@ import {
   EVENT_METHOD_OVERRIDES,
   generateEventFilters,
   generateEventTypeExports,
-  generateGetEventOverload,
+  generateGetEvent,
   generateInterfaceEventDescription,
 } from './events'
 import {
   codegenFunctions,
   generateDecodeFunctionResultOverload,
   generateEncodeFunctionDataOverload,
+  generateGetFunction,
   generateInterfaceFunctionDescription,
   generateParamNames,
 } from './functions'
@@ -34,33 +37,33 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
 
   export interface ${contract.name}Interface extends utils.Interface {
     contractName: '${contract.name}';
+
     functions: {
       ${values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
+        .flatMap((v) => v.map(generateInterfaceFunctionDescription))
         .join('\n')}
     };
-
-    ${values(contract.functions)
-      .map((v) => v[0])
-      .map(generateEncodeFunctionDataOverload)
-      .join('\n')}
-
-    ${values(contract.functions)
-      .map((v) => v[0])
-      .map(generateDecodeFunctionResultOverload)
-      .join('\n')}
 
     events: {
       ${values(contract.events)
-        .map((v) => v[0])
-        .map(generateInterfaceEventDescription)
+        .flatMap((v) => v.map(generateInterfaceEventDescription))
         .join('\n')}
     };
 
+    ${values(contract.functions)
+      .flatMap((v) => processDeclaration(v, codegenConfig.alwaysGenerateOverloads, generateGetFunction))
+      .join('\n')}
+
+    ${values(contract.functions)
+      .flatMap((v) => processDeclaration(v, codegenConfig.alwaysGenerateOverloads, generateEncodeFunctionDataOverload))
+      .join('\n')}
+
+    ${values(contract.functions)
+      .flatMap((v) => processDeclaration(v, codegenConfig.alwaysGenerateOverloads, generateDecodeFunctionResultOverload))
+      .join('\n')}
+
     ${values(contract.events)
-      .map((v) => v[0])
-      .map(generateGetEventOverload)
+      .flatMap((v) => processDeclaration(v, codegenConfig.alwaysGenerateOverloads, generateGetEvent))
       .join('\n')}
   }
 
@@ -337,4 +340,16 @@ function generateLibraryAddressesInterface(contract: Contract, bytecode: Bytecod
   export interface ${contract.name}LibraryAddresses {
     ${linkLibrariesKeys.join('\n')}
   };`
+}
+
+function processDeclaration<D extends FunctionDeclaration | EventDeclaration>(fns: (D)[], forceGenerateOverloads: boolean, stringGen: (fn: D, useSignature: boolean) => string) {
+  // Function is overloaded, we need unambiguous signatures
+  if (fns.length > 1) {
+    return fns.map((fn) => stringGen(fn, true))
+  }
+  const result = [stringGen(fns[0], false)]
+  if (forceGenerateOverloads) {
+    result.push(stringGen(fns[0], true))
+  }
+  return result
 }


### PR DESCRIPTION
Nothing fancy, here are the changes:

The methods 

```
getEvent
getFunction
decodeFunctionResult
encodeFunctionData
```

on the `ContractiInterface` of the `ethers-v5` target now follow the following rules:

- If these entities are not overloaded in the contract ABI and `--always-generate-overloads` is off, just the entities' names are used (without the signature)
- If the entities are overloaded, only signatures are used to disambiguate them
- If `--always-generate-overloads` is on, additional overloads are generated for functions that are not ambiguous

For the method and event names in the `events` and `functions` properties _only_ signature names are used (that's according to the ethers API - they don't use shorthand naming).