### PR TITLE
Crash Ethers V5 target if TS version < 4.3

### DIFF
--- a/packages/target-ethers-v5/package.json
+++ b/packages/target-ethers-v5/package.json
@@ -48,7 +48,9 @@
     "ethers": "^5.1.3",
     "test-utils": "1.0.0",
     "typechain": "workspace:^7.0.1",
-    "typescript": ">=4.3.0"
+    "typescript": ">=4.3.0",
+    "@types/proxyquire": "^1.3.28",
+    "proxyquire": "^2.1.3"
   },
   "dependencies": {
     "lodash": "^4.17.15",

--- a/packages/target-ethers-v5/test/typescript-version.test.ts
+++ b/packages/target-ethers-v5/test/typescript-version.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+import { expect, Mock, mockFn } from 'earljs'
+import proxyquire from 'proxyquire'
+
+describe('Ethers target constructor', () => {
+  const consoleError = console.error
+  let consoleErrorMock: Mock.Of<typeof console.error>
+
+  beforeEach(() => {
+    consoleErrorMock = mockFn<typeof console.error>(() => {})
+    console.error = consoleErrorMock
+  })
+
+  afterEach(() => {
+    console.error = consoleError
+  })
+
+  it('panics when TypeScript version is lower than 4.3', () => {
+    const mod = proxyquire('../src', { typescript: { version: '4.2' } }) as typeof import('../src')
+
+    const { default: EthersTarget } = mod
+
+    expect(() => {
+      const _ = new EthersTarget({
+        flags: { alwaysGenerateOverloads: false, discriminateTypes: false, environment: 'hardhat' },
+        filesToProcess: ['woop'],
+        cwd: '',
+        allFiles: ['woop'],
+        target: 'ethers-v5',
+      })
+    }).toThrow('@typechain/ethers-v5 9.0.0 needs TypeScript version 4.3 or newer.')
+
+    const message = consoleErrorMock.calls[0].args[0]
+
+    expect(message).toEqual(expect.stringMatching('@typechain/ethers-v5 9.0.0 needs TypeScript version 4.3 or newer.'))
+    expect(message).toEqual(
+      expect.stringMatching('Generated code will cause syntax errors in older TypeScript versions.'),
+    )
+    expect(message).toEqual(expect.stringMatching('Your TypeScript version is 4.2.'))
+  })
+
+  it('works when TypeScript version is 4.3 or newer', () => {
+    for (const version of ['4.3.0', '4.4.0']) {
+      const mod = proxyquire('../src', { typescript: { version } }) as typeof import('../src')
+
+      const { default: EthersTarget } = mod
+
+      expect(() => {
+        const _ = new EthersTarget({
+          flags: { alwaysGenerateOverloads: false, discriminateTypes: false, environment: 'hardhat' },
+          filesToProcess: ['woop'],
+          cwd: '',
+          allFiles: ['woop'],
+          target: 'ethers-v5',
+        })
+      }).not.toThrow()
+
+      expect(consoleErrorMock.calls).toEqual([])
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,10 @@ importers:
       '@ethersproject/bytes': ^5.0.0
       '@ethersproject/providers': ^5.0.0
       '@types/lodash': ^4.14.139
+      '@types/proxyquire': ^1.3.28
       ethers: ^5.1.3
       lodash: ^4.17.15
+      proxyquire: ^2.1.3
       test-utils: 1.0.0
       ts-essentials: ^7.0.1
       typechain: workspace:^7.0.1
@@ -281,7 +283,9 @@ importers:
       '@ethersproject/bytes': 5.6.0
       '@ethersproject/providers': 5.6.0
       '@types/lodash': 4.14.179
+      '@types/proxyquire': 1.3.28
       ethers: 5.6.0
+      proxyquire: 2.1.3
       test-utils: link:../test-utils
       typechain: link:../typechain
       typescript: 4.6.2
@@ -2948,6 +2952,10 @@ packages:
 
   /@types/prettier/2.2.3:
     resolution: {integrity: sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==}
+
+  /@types/proxyquire/1.3.28:
+    resolution: {integrity: sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==}
+    dev: true
 
   /@types/qs/6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -7054,6 +7062,14 @@ packages:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     optional: true
 
+  /fill-keys/1.0.2:
+    resolution: {integrity: sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-object: 1.0.2
+      merge-descriptors: 1.0.1
+    dev: true
+
   /fill-range/4.0.0:
     resolution: {integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=}
     engines: {node: '>=0.10.0'}
@@ -9997,6 +10013,10 @@ packages:
   /mock-fs/4.14.0:
     resolution: {integrity: sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==}
 
+  /module-not-found-error/1.0.1:
+    resolution: {integrity: sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=}
+    dev: true
+
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
 
@@ -11405,6 +11425,14 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  /proxyquire/2.1.3:
+    resolution: {integrity: sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==}
+    dependencies:
+      fill-keys: 1.0.2
+      module-not-found-error: 1.0.1
+      resolve: 1.22.0
+    dev: true
 
   /prr/1.0.1:
     resolution: {integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=}


### PR DESCRIPTION
Looks more or less like this:

![2022-03-18-13-59-45](https://user-images.githubusercontent.com/15332326/159011046-909bb832-98ea-44c2-b434-c42f613d3eff.png)
