### PR TITLE
Write TypeChain just once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
   <img src="/docs/images/typechain-logo.png" width="300" alt="TypeChain">
-  <h3 align="center">TypeChain</h3>
   <p align="center">🔌 TypeScript bindings for Ethereum smart contracts</p>
 
   <p align="center">


### PR DESCRIPTION
###  What's changed

At this moment our readme says:

> _TypeChain_
> _TypeChain_

After this change, there's only one _TypeChain_, the one in the image (and its alt text).