### PR TITLE
Type migration in truffle-v5 example

### DIFF
--- a/examples/truffle-v5/migrations-ts/1_initial_migration.ts
+++ b/examples/truffle-v5/migrations-ts/1_initial_migration.ts
@@ -1,8 +1,10 @@
 const Migrations = artifacts.require('Migrations')
 
-module.exports = function (deployer) {
+const migration: Truffle.Migration = function (deployer) {
   deployer.deploy(Migrations)
-} as Truffle.Migration
+}
+
+module.exports = migration
 
 // because of https://stackoverflow.com/questions/40900791/cannot-redeclare-block-scoped-variable-in-unrelated-files
 export {}

--- a/examples/truffle-v5/migrations-ts/2_deploy_contracts.ts
+++ b/examples/truffle-v5/migrations-ts/2_deploy_contracts.ts
@@ -1,11 +1,13 @@
 const ConvertLib = artifacts.require('ConvertLib')
 const MetaCoin = artifacts.require('MetaCoin')
 
-module.exports = function (deployer) {
+const migration: Truffle.Migration = function (deployer) {
   deployer.deploy(ConvertLib)
   deployer.link(ConvertLib, MetaCoin)
   deployer.deploy(MetaCoin)
-} as Truffle.Migration
+}
+
+module.exports = migration
 
 // because of https://stackoverflow.com/questions/40900791/cannot-redeclare-block-scoped-variable-in-unrelated-files
 export {}


### PR DESCRIPTION
Migration functions in the truffle-v5 example are cast, thus providing on type safety nor autocompletion. In the following, `deployer` has type `any`:

```ts
module.exports = function (deployer) {
   deployer.deploy(Migrations)
} as Truffle.Migration
```

This PR changes to a slightly longer format where `deployer`'s type is recognized as `Truffle.Deployer`:

```ts
const migration: Truffle.Migration = (deployer) => {
  deployer.deploy(Migrations);
};
module.exports = migration;
```