### PR TITLE
feat(codegen): reduce needed imports

### DIFF
--- a/packages/target-ethers-v5/static/common.ts
+++ b/packages/target-ethers-v5/static/common.ts
@@ -1,5 +1,5 @@
 import type { Listener } from '@ethersproject/providers'
-import type { Event, EventFilter } from 'ethers'
+import type { Event, EventFilter } from '@ethersproject/contracts'
 
 export interface TypedEvent<TArgsArray extends Array<any> = any, TArgsObject = any> extends Event {
   args: TArgsArray & TArgsObject


### PR DESCRIPTION
Opening this PR to see if you are open to directly importing from @ethersproject packages rather than ethers umbrella.

This *may* be a breaking change? 

Here is a trivial example before we get too deep:
 
These two imports can be taken directly from the @ethersproject/contracts package. no need for umbrella import, should be a drop in.

next
```typescript
import type { BaseContract, Signer, utils } from "ethers";
```