### PR TITLE
Feature/exclude gas from abi

### DIFF
--- a/packages/target-ethers-v5/test/generation.test.ts
+++ b/packages/target-ethers-v5/test/generation.test.ts
@@ -37,6 +37,35 @@ describe('Ethers generation edge cases', () => {
     expect(source).toEqual(expect.stringMatching(/export class TestContract__factory extends ContractFactory \{/))
     expect(source).toEqual(expect.stringMatching(/static linkBytecode\(/))
   })
+
+  it('should exclude gas field from ABI', () => {
+    const abi = [
+      {
+        stateMutability: 'view',
+        type: 'function',
+        name: 'foo',
+        inputs: [
+          {
+            name: 'bar',
+            type: 'address',
+          },
+        ],
+        outputs: [
+          {
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        gas: 3135,
+      },
+    ]
+
+    const source = codegenContractFactory(DEFAULT_FLAGS, emptyContract, abi, {
+      bytecode: '{{BYTECODE}}',
+    })
+
+    expect(source).not.toEqual(expect.stringMatching(/"gas":/))
+  })
 })
 
 describe(generateEventFilters.name, () => {


### PR DESCRIPTION
Proposed fix for: https://github.com/dethcrypto/TypeChain/issues/677

Old vyper compiler versions generate `gas` estimates in the ABI. These members are:
- numbers. Since they're not strings they have incorrect types types when the _abi is passed to ethers `Contract` for example.
- The gas estimates are actually incorrect anyway - so even if they were stringified, `gasLimit` overrides would need to be set all over the place.

Easiest solution is to remove the `gas` field in the generated typechain factory code.