### PR TITLE
Add `dontOverrideCompile` setting and fix a bug

### DIFF
--- a/examples/hardhat-truffe-v5/package.json
+++ b/examples/hardhat-truffe-v5/package.json
@@ -24,7 +24,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-bn": "^0.2.1",
     "dotenv": "^8.2.0",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.9.9",
     "ts-generator": "0.0.8",
     "ts-node": "^10.7.0",
     "typechain": "workspace:^8.0.0",

--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -27,7 +27,7 @@
     "@ethersproject/providers": "5.4.0",
     "@ethersproject/contracts": "5.4.0",
     "@ethersproject/abi": "5.4.0",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.9.9",
     "ts-node": "^10.7.0",
     "typechain": "workspace:^8.0.0",
     "typescript": "^4.6"

--- a/packages/hardhat-test/package.json
+++ b/packages/hardhat-test/package.json
@@ -21,7 +21,7 @@
     "@typechain/ethers-v5": "workspace:^10.0.0",
     "@typechain/hardhat": "workspace:^6.0.0",
     "ethers": "^5.4.7",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.9.9",
     "test-utils": "1.0.0",
     "typechain": "workspace:^8.0.0"
   }

--- a/packages/hardhat/README.md
+++ b/packages/hardhat/README.md
@@ -104,6 +104,7 @@ module.exports = {
     target: 'ethers-v5',
     alwaysGenerateOverloads: false, // should overloads with full signatures like deposit(uint256) be generated always, even if there are no overloads?
     externalArtifacts: ['externalArtifacts/*.json'], // optional array of glob patterns with external artifacts to process (for example external libs from node_modules)
+    dontOverrideCompile: false // defaults to true for javascript projects
   },
 }
 ```

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -42,7 +42,7 @@
     "@types/lodash": "^4.14.139",
     "@types/rimraf": "^3.0.0",
     "ethers": "^5.4.7",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.9.9",
     "rimraf": "^3.0.2",
     "typechain": "workspace:^8.0.0",
     "typescript": "^4"
@@ -52,7 +52,7 @@
     "@ethersproject/providers": "^5.4.7",
     "@typechain/ethers-v5": "workspace:^10.0.0",
     "ethers": "^5.4.7",
-    "hardhat": "^2.0.10",
+    "hardhat": "^2.9.9",
     "typechain": "workspace:^8.0.0"
   }
 }

--- a/packages/hardhat/src/config.ts
+++ b/packages/hardhat/src/config.ts
@@ -9,6 +9,7 @@ export function getDefaultTypechainConfig(config: HardhatConfig): TypechainConfi
     alwaysGenerateOverloads: false,
     discriminateTypes: false,
     tsNocheck: false,
+    dontOverrideCompile: config.paths.configFile.endsWith('.js'),
   }
 
   return {

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -18,7 +18,7 @@ extendConfig((config) => {
 
 task(TASK_COMPILE)
   .addFlag('noTypechain', 'Skip Typechain compilation')
-  .setAction(async ({ noTypechain }: { global: boolean; noTypechain: boolean }, {config}, runSuper) => {
+  .setAction(async ({ noTypechain }: { global: boolean; noTypechain: boolean }, { config }, runSuper) => {
     // just save task arguments for later b/c there is no easier way to access them in subtask
     taskArgsStore.noTypechain = noTypechain!! || config.typechain.dontOverrideCompile
 

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -18,9 +18,9 @@ extendConfig((config) => {
 
 task(TASK_COMPILE)
   .addFlag('noTypechain', 'Skip Typechain compilation')
-  .setAction(async ({ noTypechain }: { global: boolean; noTypechain: boolean }, _, runSuper) => {
+  .setAction(async ({ noTypechain }: { global: boolean; noTypechain: boolean }, {config}, runSuper) => {
     // just save task arguments for later b/c there is no easier way to access them in subtask
-    taskArgsStore.noTypechain = noTypechain!!
+    taskArgsStore.noTypechain = noTypechain!! || config.typechain.dontOverrideCompile
 
     await runSuper()
   })

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -37,9 +37,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
   .addParam('compileSolOutput', 'Solidity compilation output', {}, types.any)
   .setAction(async ({ compileSolOutput }, { config, artifacts }) => {
     const artifactFQNs: string[] = getFQNamesFromCompilationOutput(compileSolOutput)
-    const artifactPaths = uniq(
-      artifactFQNs.map((fqn) => (artifacts as any)._getArtifactPathFromFullyQualifiedName(fqn)),
-    )
+    const artifactPaths = uniq(artifactFQNs.map((fqn) => artifacts.formArtifactPathFromFullyQualifiedName(fqn)))
 
     if (taskArgsStore.noTypechain) {
       return compileSolOutput

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -16,7 +16,7 @@ extendConfig((config) => {
   config.typechain = getDefaultTypechainConfig(config)
 })
 
-task(TASK_COMPILE, 'Compiles the entire project, building all artifacts')
+task(TASK_COMPILE)
   .addFlag('noTypechain', 'Skip Typechain compilation')
   .setAction(async ({ noTypechain }: { global: boolean; noTypechain: boolean }, _, runSuper) => {
     // just save task arguments for later b/c there is no easier way to access them in subtask

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -107,7 +107,7 @@ task(
   'Clears the cache and deletes all artifacts',
   async ({ global }: { global: boolean }, { config }, runSuper) => {
     if (global) {
-      return
+      return runSuper()
     }
 
     if (await fsExtra.pathExists(config.typechain.outDir)) {

--- a/packages/hardhat/src/types.ts
+++ b/packages/hardhat/src/types.ts
@@ -5,6 +5,7 @@ export interface TypechainConfig {
   discriminateTypes: boolean
   tsNocheck: boolean
   externalArtifacts?: string[]
+  dontOverrideCompile: boolean
 }
 
 export interface TypechainUserConfig extends Partial<TypechainConfig> {}

--- a/packages/hardhat/test/fixture-projects/no-override-project/contracts/c.sol
+++ b/packages/hardhat/test/fixture-projects/no-override-project/contracts/c.sol
@@ -1,0 +1,4 @@
+pragma solidity ^0.7.3;
+
+contract C {
+}

--- a/packages/hardhat/test/fixture-projects/no-override-project/hardhat.config.ts
+++ b/packages/hardhat/test/fixture-projects/no-override-project/hardhat.config.ts
@@ -7,8 +7,8 @@ const config: HardhatUserConfig = {
   solidity: '0.7.3',
   defaultNetwork: 'hardhat',
   typechain: {
-    dontOverrideCompile: true
-  }
+    dontOverrideCompile: true,
+  },
 }
 
 export default config

--- a/packages/hardhat/test/fixture-projects/no-override-project/hardhat.config.ts
+++ b/packages/hardhat/test/fixture-projects/no-override-project/hardhat.config.ts
@@ -1,0 +1,14 @@
+// We load the plugin here.
+import '../../../src/index'
+
+import { HardhatUserConfig } from 'hardhat/types'
+
+const config: HardhatUserConfig = {
+  solidity: '0.7.3',
+  defaultNetwork: 'hardhat',
+  typechain: {
+    dontOverrideCompile: true
+  }
+}
+
+export default config

--- a/packages/hardhat/test/project.test.ts
+++ b/packages/hardhat/test/project.test.ts
@@ -131,6 +131,31 @@ describe('Typechain x Hardhat', function () {
   })
 })
 
+describe('dontOverrideCompile', function () {
+  useEnvironment('no-override-project')
+  let originalCwd: typeof process.cwd
+
+  beforeEach(async function () {
+    originalCwd = process.cwd
+    await this.hre.run('clean')
+  })
+
+  this.afterEach(async function () {
+    await this.hre.run('clean')
+    process.cwd = originalCwd
+  })
+
+  it('should desible typechain for the compile task', async function () {
+    const exists = existsSync(this.hre.config.typechain.outDir)
+    expect(exists).toEqual(false)
+
+    await this.hre.run('compile')
+
+    const existsAfter = existsSync(this.hre.config.typechain.outDir)
+    expect(existsAfter).toEqual(false)
+  })
+})
+
 const contractDir = join(__dirname, 'fixture-projects/hardhat-project/contracts')
 const fixtureFilesDir = join(__dirname, 'fixture-files')
 const TestContract2OriginPath = join(fixtureFilesDir, 'TestContract2.sol')

--- a/packages/hardhat/test/project.test.ts
+++ b/packages/hardhat/test/project.test.ts
@@ -140,8 +140,7 @@ describe('dontOverrideCompile', function () {
     await this.hre.run('clean')
   })
 
-  this.afterEach(async function () {
-    await this.hre.run('clean')
+  this.afterEach(() => {
     process.cwd = originalCwd
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,7 +221,7 @@ importers:
       '@types/rimraf': ^3.0.0
       ethers: ^5.4.7
       fs-extra: ^9.1.0
-      hardhat: ^2.0.10
+      hardhat: ^2.9.9
       lodash: ^4.17.15
       rimraf: ^3.0.2
       typechain: workspace:^8.0.0
@@ -232,13 +232,13 @@ importers:
     devDependencies:
       '@ethersproject/abi': 5.6.0
       '@ethersproject/providers': 5.6.0
-      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.6.0+hardhat@2.9.1
+      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.6.0+hardhat@2.9.9
       '@typechain/ethers-v5': link:../target-ethers-v5
       '@types/fs-extra': 9.0.13
       '@types/lodash': 4.14.179
       '@types/rimraf': 3.0.2
       ethers: 5.6.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_typescript@4.6.2
       rimraf: 3.0.2
       typechain: link:../typechain
       typescript: 4.6.2
@@ -955,6 +955,15 @@ packages:
       merkle-patricia-tree: 4.2.3
     dev: true
 
+  /@ethereumjs/block/3.6.2:
+    resolution: {integrity: sha512-mOqYWwMlAZpYUEOEqt7EfMFuVL2eyLqWWIzcf4odn6QgXY8jBI2NhVuJncrMCKeMZrsJAe7/auaRRB6YcdH+Qw==}
+    dependencies:
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/tx': 3.5.2
+      ethereumjs-util: 7.1.5
+      merkle-patricia-tree: 4.2.4
+    dev: true
+
   /@ethereumjs/blockchain/5.5.1:
     resolution: {integrity: sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==}
     dependencies:
@@ -970,11 +979,33 @@ packages:
       - supports-color
     dev: true
 
+  /@ethereumjs/blockchain/5.5.3:
+    resolution: {integrity: sha512-bi0wuNJ1gw4ByNCV56H0Z4Q7D+SxUbwyG12Wxzbvqc89PXLRNR20LBcSUZRKpN0+YCPo6m0XZL/JLio3B52LTw==}
+    dependencies:
+      '@ethereumjs/block': 3.6.2
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/ethash': 1.1.0
+      debug: 4.3.3
+      ethereumjs-util: 7.1.5
+      level-mem: 5.0.1
+      lru-cache: 5.1.1
+      semaphore-async-await: 1.5.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@ethereumjs/common/2.6.2:
     resolution: {integrity: sha512-vDwye5v0SVeuDky4MtKsu+ogkH2oFUV8pBKzH/eNBzT8oI91pKa8WyzDuYuxOQsgNgv5R34LfFDh2aaw3H4HbQ==}
     dependencies:
       crc-32: 1.2.1
       ethereumjs-util: 7.1.4
+
+  /@ethereumjs/common/2.6.4:
+    resolution: {integrity: sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==}
+    dependencies:
+      crc-32: 1.2.1
+      ethereumjs-util: 7.1.5
+    dev: true
 
   /@ethereumjs/ethash/1.1.0:
     resolution: {integrity: sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==}
@@ -992,6 +1023,13 @@ packages:
       '@ethereumjs/common': 2.6.2
       ethereumjs-util: 7.1.4
 
+  /@ethereumjs/tx/3.5.2:
+    resolution: {integrity: sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==}
+    dependencies:
+      '@ethereumjs/common': 2.6.4
+      ethereumjs-util: 7.1.5
+    dev: true
+
   /@ethereumjs/vm/5.7.1:
     resolution: {integrity: sha512-NiFm5FMaeDGZ9ojBL+Y9Y/xhW6S4Fgez+zPBM402T5kLsfeAR9mrRVckYhvkGVJ6FMwsY820CLjYP5OVwMjLTg==}
     dependencies:
@@ -1006,6 +1044,25 @@ packages:
       functional-red-black-tree: 1.0.1
       mcl-wasm: 0.7.9
       merkle-patricia-tree: 4.2.3
+      rustbn.js: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@ethereumjs/vm/5.9.2:
+    resolution: {integrity: sha512-6zvH7iuMI7+74aGak6j9+GDYpV2T08vy2FL4iSK1PId7lNyjFELCAzDCSTQcVoyPoRMkZvRHy79W+djwvguMCA==}
+    dependencies:
+      '@ethereumjs/block': 3.6.2
+      '@ethereumjs/blockchain': 5.5.3
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/tx': 3.5.2
+      async-eventemitter: 0.2.4
+      core-js-pure: 3.21.1
+      debug: 4.3.3
+      ethereumjs-util: 7.1.5
+      functional-red-black-tree: 1.0.1
+      mcl-wasm: 0.7.9
+      merkle-patricia-tree: 4.2.4
       rustbn.js: 0.2.0
     transitivePeerDependencies:
       - supports-color
@@ -1954,6 +2011,16 @@ packages:
     dependencies:
       ethers: 5.6.0
       hardhat: 2.9.1
+    dev: true
+
+  /@nomiclabs/hardhat-ethers/2.0.5_ethers@5.6.0+hardhat@2.9.9:
+    resolution: {integrity: sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==}
+    peerDependencies:
+      ethers: ^5.0.0
+      hardhat: ^2.0.0
+    dependencies:
+      ethers: 5.6.0
+      hardhat: 2.9.9_typescript@4.6.2
     dev: true
 
   /@nomiclabs/hardhat-etherscan/2.1.8_hardhat@2.9.1:
@@ -4049,7 +4116,7 @@ packages:
     resolution: {integrity: sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==}
     deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9_debug@4.3.3
     transitivePeerDependencies:
       - debug
     optional: true
@@ -4057,14 +4124,14 @@ packages:
   /axios/0.23.0:
     resolution: {integrity: sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9_debug@4.3.3
     transitivePeerDependencies:
       - debug
 
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9_debug@4.3.3
     transitivePeerDependencies:
       - debug
     dev: true
@@ -4072,7 +4139,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9_debug@4.3.3
     transitivePeerDependencies:
       - debug
 
@@ -4905,7 +4972,7 @@ packages:
     dev: true
 
   /bs58/4.0.1:
-    resolution: {integrity: sha1-vhYedsNU9veIrkBx9j806MTwpCo=}
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
       base-x: 3.0.9
 
@@ -4947,7 +5014,7 @@ packages:
     resolution: {integrity: sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ==}
 
   /buffer-xor/1.0.3:
-    resolution: {integrity: sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=}
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
 
   /buffer-xor/2.0.2:
     resolution: {integrity: sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==}
@@ -5452,7 +5519,7 @@ packages:
     resolution: {integrity: sha1-5WJF7ymCJlcRDHy3WpzXhstp7Rs=}
 
   /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -6434,7 +6501,7 @@ packages:
     resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
 
   /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
   /escape-string-regexp/2.0.0:
@@ -7051,6 +7118,17 @@ packages:
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
 
+  /ethereumjs-util/7.1.5:
+    resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@types/bn.js': 5.1.0
+      bn.js: 5.2.0
+      create-hash: 1.2.0
+      ethereum-cryptography: 0.1.3
+      rlp: 2.2.7
+    dev: true
+
   /ethereumjs-vm/2.6.0:
     resolution: {integrity: sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==}
     deprecated: 'New package name format for new versions: @ethereumjs/vm. Please update.'
@@ -7552,7 +7630,7 @@ packages:
     dev: true
 
   /find-up/2.1.0:
-    resolution: {integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=}
+    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
     dependencies:
       locate-path: 2.0.0
@@ -7637,6 +7715,18 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
+    dev: true
+
+  /follow-redirects/1.14.9_debug@4.3.3:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.3
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -7705,9 +7795,9 @@ packages:
     engines: {node: '>= 0.6'}
 
   /fs-extra/0.30.0:
-    resolution: {integrity: sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=}
+    resolution: {integrity: sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==}
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
       jsonfile: 2.4.0
       klaw: 1.3.1
       path-is-absolute: 1.0.1
@@ -7760,7 +7850,7 @@ packages:
       minipass: 2.9.0
 
   /fs.realpath/1.0.0:
-    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   /fsevents/2.1.3:
     resolution: {integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==}
@@ -8151,6 +8241,74 @@ packages:
       - utf-8-validate
     dev: true
 
+  /hardhat/2.9.9_typescript@4.6.2:
+    resolution: {integrity: sha512-Qv7SXnRc0zq1kGXruNnSKpP3eFccXMR5Qv6GVX9hBIJ5efN0PflKPq92aQ5Cv3jrjJeRevLznWZVz7bttXhVfw==}
+    engines: {node: ^12.0.0 || ^14.0.0 || ^16.0.0}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@ethereumjs/block': 3.6.2
+      '@ethereumjs/blockchain': 5.5.3
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/tx': 3.5.2
+      '@ethereumjs/vm': 5.9.2
+      '@ethersproject/abi': 5.6.0
+      '@metamask/eth-sig-util': 4.0.0
+      '@sentry/node': 5.30.0
+      '@solidity-parser/parser': 0.14.1
+      '@types/bn.js': 5.1.0
+      '@types/lru-cache': 5.1.1
+      abort-controller: 3.0.0
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      chalk: 2.4.2
+      chokidar: 3.5.3
+      ci-info: 2.0.0
+      debug: 4.3.3
+      enquirer: 2.3.6
+      env-paths: 2.2.1
+      ethereum-cryptography: 0.1.3
+      ethereumjs-abi: 0.6.8
+      ethereumjs-util: 7.1.5
+      find-up: 2.1.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      glob: 7.2.0
+      immutable: 4.0.0
+      io-ts: 1.10.4
+      lodash: 4.17.21
+      merkle-patricia-tree: 4.2.4
+      mnemonist: 0.38.5
+      mocha: 9.2.2
+      p-map: 4.0.0
+      qs: 6.10.3
+      raw-body: 2.5.1
+      resolve: 1.17.0
+      semver: 6.3.0
+      slash: 3.0.0
+      solc: 0.7.3_debug@4.3.3
+      source-map-support: 0.5.20
+      stacktrace-parser: 0.1.10
+      true-case-path: 2.2.1
+      tsort: 0.0.1
+      typescript: 4.6.2
+      undici: 5.4.0
+      uuid: 8.3.2
+      ws: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /has-ansi/2.0.0:
     resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
     engines: {node: '>=0.10.0'}
@@ -8161,7 +8319,7 @@ packages:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
 
   /has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
 
   /has-flag/4.0.0:
@@ -8443,7 +8601,7 @@ packages:
     dev: true
 
   /inflight/1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -9442,9 +9600,9 @@ packages:
     optional: true
 
   /jsonfile/2.4.0:
-    resolution: {integrity: sha1-NzaitCi4e72gzIO1P6PWM6NcKug=}
+    resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonfile/4.0.0:
@@ -9457,7 +9615,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
 
   /jsonify/0.0.0:
     resolution: {integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=}
@@ -9532,9 +9690,9 @@ packages:
     dev: true
 
   /klaw/1.3.1:
-    resolution: {integrity: sha1-QIhDO0azsbolnXh4XY6W9zugJDk=}
+    resolution: {integrity: sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==}
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
     dev: true
 
   /lcid/1.0.0:
@@ -9873,7 +10031,7 @@ packages:
     dev: true
 
   /locate-path/2.0.0:
-    resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=}
+    resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
     dependencies:
       p-locate: 2.0.0
@@ -10173,7 +10331,7 @@ packages:
     dev: true
 
   /memorystream/0.3.1:
-    resolution: {integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=}
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
     dev: true
 
@@ -10243,6 +10401,17 @@ packages:
     dependencies:
       '@types/levelup': 4.3.3
       ethereumjs-util: 7.1.4
+      level-mem: 5.0.1
+      level-ws: 2.0.0
+      readable-stream: 3.6.0
+      semaphore-async-await: 1.5.1
+    dev: true
+
+  /merkle-patricia-tree/4.2.4:
+    resolution: {integrity: sha512-eHbf/BG6eGNsqqfbLED9rIqbsF4+sykEaBn6OLNs71tjclbMcMOk1tEPmJKcNcNCLkvbpY/lwyOlizWsqPNo8w==}
+    dependencies:
+      '@types/levelup': 4.3.3
+      ethereumjs-util: 7.1.5
       level-mem: 5.0.1
       level-ws: 2.0.0
       readable-stream: 3.6.0
@@ -11064,7 +11233,7 @@ packages:
       ee-first: 1.1.1
 
   /once/1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
 
@@ -11210,7 +11379,7 @@ packages:
       yocto-queue: 0.1.0
 
   /p-locate/2.0.0:
-    resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
+    resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
     dependencies:
       p-limit: 1.3.0
@@ -11253,7 +11422,7 @@ packages:
       p-finally: 1.0.0
 
   /p-try/1.0.0:
-    resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
+    resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
 
   /p-try/2.2.0:
@@ -11408,7 +11577,7 @@ packages:
     dev: true
 
   /path-exists/3.0.0:
-    resolution: {integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=}
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
 
   /path-exists/4.0.0:
@@ -12261,7 +12430,7 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: true
 
   /receptacle/1.3.2:
@@ -12410,7 +12579,7 @@ packages:
       uuid: 3.4.0
 
   /require-directory/2.1.1:
-    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
   /require-from-string/1.2.1:
@@ -12466,7 +12635,7 @@ packages:
   /resolve/1.17.0:
     resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
     dependencies:
-      path-parse: 1.0.6
+      path-parse: 1.0.7
     dev: true
 
   /resolve/1.20.0:
@@ -13017,6 +13186,24 @@ packages:
       command-exists: 1.2.9
       commander: 3.0.2
       follow-redirects: 1.14.9_debug@4.3.2
+      fs-extra: 0.30.0
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      require-from-string: 2.0.2
+      semver: 5.7.1
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
+  /solc/0.7.3_debug@4.3.3:
+    resolution: {integrity: sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      command-exists: 1.2.9
+      commander: 3.0.2
+      follow-redirects: 1.14.9_debug@4.3.3
       fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
@@ -14115,7 +14302,6 @@ packages:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /typewise-core/1.2.0:
     resolution: {integrity: sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=}
@@ -14189,6 +14375,11 @@ packages:
 
   /undici/4.15.1:
     resolution: {integrity: sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==}
+    engines: {node: '>=12.18'}
+    dev: true
+
+  /undici/5.4.0:
+    resolution: {integrity: sha512-A1SRXysDg7J+mVP46jF+9cKANw0kptqSFZ8tGyL+HBiv0K1spjxPX8Z4EGu+Eu6pjClJUBdnUPlxrOafR668/g==}
     engines: {node: '>=12.18'}
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
       dotenv: ^8.2.0
       ethereum-waffle: ^3.2.2
       ethers: 5.4.0
-      hardhat: ^2.0.10
+      hardhat: ^2.9.9
       ts-node: ^10.7.0
       typechain: workspace:^8.0.0
       typescript: ^4.6
@@ -87,8 +87,8 @@ importers:
       '@ethersproject/abi': 5.4.0
       '@ethersproject/contracts': 5.4.0
       '@ethersproject/providers': 5.4.0
-      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.4.0+hardhat@2.9.1
-      '@nomiclabs/hardhat-waffle': 2.0.3_rpwx6hi5gkf3to7hjwsvdhssmm
+      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.4.0+hardhat@2.9.9
+      '@nomiclabs/hardhat-waffle': 2.0.3_vg5rnw7vapjgnnmlrqsnbl36dq
       '@typechain/ethers-v5': link:../../packages/target-ethers-v5
       '@typechain/hardhat': link:../../packages/hardhat
       '@types/chai': 4.3.0
@@ -100,7 +100,7 @@ importers:
       dotenv: 8.6.0
       ethereum-waffle: 3.4.0_typescript@4.6.2
       ethers: 5.4.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
       ts-node: 10.7.0_55hvwysvdsti7rc6ljwd3v4ani
       typechain: link:../../packages/typechain
       typescript: 4.6.2
@@ -122,7 +122,7 @@ importers:
       chai-as-promised: ^7.1.1
       chai-bn: ^0.2.1
       dotenv: ^8.2.0
-      hardhat: ^2.0.10
+      hardhat: ^2.9.9
       ts-generator: 0.0.8
       ts-node: ^10.7.0
       typechain: workspace:^8.0.0
@@ -135,9 +135,9 @@ importers:
       web3-eth-contract: ^1
       web3-utils: ^1.2.1
     devDependencies:
-      '@nomiclabs/hardhat-etherscan': 2.1.8_hardhat@2.9.1
-      '@nomiclabs/hardhat-truffle5': 2.0.5_c3afxrbmmora2acr47l3xhk6mu
-      '@nomiclabs/hardhat-web3': 2.0.0_hardhat@2.9.1+web3@1.7.1
+      '@nomiclabs/hardhat-etherscan': 2.1.8_hardhat@2.9.9
+      '@nomiclabs/hardhat-truffle5': 2.0.5_gqs53m7ishxrwvuy4vik3wgdya
+      '@nomiclabs/hardhat-web3': 2.0.0_hardhat@2.9.9+web3@1.7.1
       '@typechain/hardhat': link:../../packages/hardhat
       '@typechain/truffle-v5': link:../../packages/target-truffle-v5
       '@types/bn.js': 4.11.6
@@ -150,7 +150,7 @@ importers:
       chai-as-promised: 7.1.1_chai@4.3.6
       chai-bn: 0.2.2_bn.js@4.12.0+chai@4.3.6
       dotenv: 8.6.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
       ts-generator: 0.0.8
       ts-node: 10.7.0_55hvwysvdsti7rc6ljwd3v4ani
       typechain: link:../../packages/typechain
@@ -251,17 +251,17 @@ importers:
       '@typechain/ethers-v5': workspace:^10.0.0
       '@typechain/hardhat': workspace:^6.0.0
       ethers: ^5.4.7
-      hardhat: ^2.0.10
+      hardhat: ^2.9.9
       test-utils: 1.0.0
       typechain: workspace:^8.0.0
     devDependencies:
       '@ethersproject/abi': 5.6.0
       '@ethersproject/providers': 5.6.0
-      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.6.0+hardhat@2.9.1
+      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.6.0+hardhat@2.9.9
       '@typechain/ethers-v5': link:../target-ethers-v5
       '@typechain/hardhat': link:../hardhat
       ethers: 5.6.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9
       test-utils: link:../test-utils
       typechain: link:../typechain
 
@@ -946,15 +946,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@ethereumjs/block/3.6.1:
-    resolution: {integrity: sha512-o5d/zpGl4SdVfdTfrsq9ZgYMXddc0ucKMiFW5OphBCX+ep4xzYnSjboFcZXT2V/tcSBr84VrKWWp21CGVb3DGw==}
-    dependencies:
-      '@ethereumjs/common': 2.6.2
-      '@ethereumjs/tx': 3.5.0
-      ethereumjs-util: 7.1.4
-      merkle-patricia-tree: 4.2.3
-    dev: true
-
   /@ethereumjs/block/3.6.2:
     resolution: {integrity: sha512-mOqYWwMlAZpYUEOEqt7EfMFuVL2eyLqWWIzcf4odn6QgXY8jBI2NhVuJncrMCKeMZrsJAe7/auaRRB6YcdH+Qw==}
     dependencies:
@@ -962,21 +953,6 @@ packages:
       '@ethereumjs/tx': 3.5.2
       ethereumjs-util: 7.1.5
       merkle-patricia-tree: 4.2.4
-    dev: true
-
-  /@ethereumjs/blockchain/5.5.1:
-    resolution: {integrity: sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==}
-    dependencies:
-      '@ethereumjs/block': 3.6.1
-      '@ethereumjs/common': 2.6.2
-      '@ethereumjs/ethash': 1.1.0
-      debug: 2.6.9
-      ethereumjs-util: 7.1.4
-      level-mem: 5.0.1
-      lru-cache: 5.1.1
-      semaphore-async-await: 1.5.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@ethereumjs/blockchain/5.5.3:
@@ -1010,10 +986,10 @@ packages:
   /@ethereumjs/ethash/1.1.0:
     resolution: {integrity: sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==}
     dependencies:
-      '@ethereumjs/block': 3.6.1
+      '@ethereumjs/block': 3.6.2
       '@types/levelup': 4.3.3
       buffer-xor: 2.0.2
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       miller-rabin: 4.0.1
     dev: true
 
@@ -1028,25 +1004,6 @@ packages:
     dependencies:
       '@ethereumjs/common': 2.6.4
       ethereumjs-util: 7.1.5
-    dev: true
-
-  /@ethereumjs/vm/5.7.1:
-    resolution: {integrity: sha512-NiFm5FMaeDGZ9ojBL+Y9Y/xhW6S4Fgez+zPBM402T5kLsfeAR9mrRVckYhvkGVJ6FMwsY820CLjYP5OVwMjLTg==}
-    dependencies:
-      '@ethereumjs/block': 3.6.1
-      '@ethereumjs/blockchain': 5.5.1
-      '@ethereumjs/common': 2.6.2
-      '@ethereumjs/tx': 3.5.0
-      async-eventemitter: 0.2.4
-      core-js-pure: 3.21.1
-      debug: 4.3.3
-      ethereumjs-util: 7.1.4
-      functional-red-black-tree: 1.0.1
-      mcl-wasm: 0.7.9
-      merkle-patricia-tree: 4.2.3
-      rustbn.js: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@ethereumjs/vm/5.9.2:
@@ -1993,24 +1950,14 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@nomiclabs/hardhat-ethers/2.0.5_ethers@5.4.0+hardhat@2.9.1:
+  /@nomiclabs/hardhat-ethers/2.0.5_ethers@5.4.0+hardhat@2.9.9:
     resolution: {integrity: sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==}
     peerDependencies:
       ethers: ^5.0.0
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.4.0
-      hardhat: 2.9.1
-    dev: true
-
-  /@nomiclabs/hardhat-ethers/2.0.5_ethers@5.6.0+hardhat@2.9.1:
-    resolution: {integrity: sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==}
-    peerDependencies:
-      ethers: ^5.0.0
-      hardhat: ^2.0.0
-    dependencies:
-      ethers: 5.6.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
     dev: true
 
   /@nomiclabs/hardhat-ethers/2.0.5_ethers@5.6.0+hardhat@2.9.9:
@@ -2023,7 +1970,7 @@ packages:
       hardhat: 2.9.9_typescript@4.6.2
     dev: true
 
-  /@nomiclabs/hardhat-etherscan/2.1.8_hardhat@2.9.1:
+  /@nomiclabs/hardhat-etherscan/2.1.8_hardhat@2.9.9:
     resolution: {integrity: sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==}
     peerDependencies:
       hardhat: ^2.0.4
@@ -2033,7 +1980,7 @@ packages:
       cbor: 5.2.0
       debug: 4.3.3
       fs-extra: 7.0.1
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
       node-fetch: 2.6.7
       semver: 6.3.0
     transitivePeerDependencies:
@@ -2041,20 +1988,20 @@ packages:
       - supports-color
     dev: true
 
-  /@nomiclabs/hardhat-truffle5/2.0.5_c3afxrbmmora2acr47l3xhk6mu:
+  /@nomiclabs/hardhat-truffle5/2.0.5_gqs53m7ishxrwvuy4vik3wgdya:
     resolution: {integrity: sha512-taTWfieMP3Rvj+y90DgdNpviUJ4zxgjpW0V8D++uPkg5R7HXVWBTf43a1PYw+cBhcqN29P9gB1zSS1HC+uz1Mw==}
     peerDependencies:
       '@nomiclabs/hardhat-web3': ^2.0.0
       hardhat: ^2.6.4
       web3: ^1.0.0-beta.36
     dependencies:
-      '@nomiclabs/hardhat-web3': 2.0.0_hardhat@2.9.1+web3@1.7.1
+      '@nomiclabs/hardhat-web3': 2.0.0_hardhat@2.9.9+web3@1.7.1
       '@nomiclabs/truffle-contract': 4.2.23_qii3q2i72zrwjhm3iok2jabb7m
       '@types/chai': 4.3.0
       chai: 4.3.6
       ethereumjs-util: 7.1.4
       fs-extra: 7.0.1
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
       web3: 1.7.1
     transitivePeerDependencies:
       - bufferutil
@@ -2066,7 +2013,7 @@ packages:
       - web3-utils
     dev: true
 
-  /@nomiclabs/hardhat-waffle/2.0.3_rpwx6hi5gkf3to7hjwsvdhssmm:
+  /@nomiclabs/hardhat-waffle/2.0.3_vg5rnw7vapjgnnmlrqsnbl36dq:
     resolution: {integrity: sha512-049PHSnI1CZq6+XTbrMbMv5NaL7cednTfPenx02k3cEh8wBMLa6ys++dBETJa6JjfwgA9nBhhHQ173LJv6k2Pg==}
     peerDependencies:
       '@nomiclabs/hardhat-ethers': ^2.0.0
@@ -2074,22 +2021,22 @@ packages:
       ethers: ^5.0.0
       hardhat: ^2.0.0
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.4.0+hardhat@2.9.1
+      '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.4.0+hardhat@2.9.9
       '@types/sinon-chai': 3.2.8
       '@types/web3': 1.0.19
       ethereum-waffle: 3.4.0_typescript@4.6.2
       ethers: 5.4.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
     dev: true
 
-  /@nomiclabs/hardhat-web3/2.0.0_hardhat@2.9.1+web3@1.7.1:
+  /@nomiclabs/hardhat-web3/2.0.0_hardhat@2.9.9+web3@1.7.1:
     resolution: {integrity: sha512-zt4xN+D+fKl3wW2YlTX3k9APR3XZgPkxJYf36AcliJn3oujnKEVRZaHu0PhgLjO+gR+F/kiYayo9fgd2L8970Q==}
     peerDependencies:
       hardhat: ^2.0.0
       web3: ^1.0.0-beta.36
     dependencies:
       '@types/bignumber.js': 5.0.0
-      hardhat: 2.9.1
+      hardhat: 2.9.9_ydznwdtnuvt5v5poxvazn5c734
       web3: 1.7.1
     dev: true
 
@@ -3556,7 +3503,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       buffer: 5.7.1
-      immediate: 3.2.3
+      immediate: 3.3.0
       level-concat-iterator: 2.0.1
       level-supports: 1.0.1
       xtend: 4.0.2
@@ -7705,18 +7652,6 @@ packages:
     resolution: {integrity: sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=}
     dev: true
 
-  /follow-redirects/1.14.9_debug@4.3.2:
-    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.2
-    dev: true
-
   /follow-redirects/1.14.9_debug@4.3.3:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
     engines: {node: '>=4.0'}
@@ -8182,16 +8117,24 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /hardhat/2.9.1:
-    resolution: {integrity: sha512-q0AkYXV7R26RzyAkHGQRhhQjk508pseVvH3wSwZwwPUbvA+tjl0vMIrD4aFQDonRXkrnXX4+5KglozzjSd0//Q==}
+  /hardhat/2.9.9:
+    resolution: {integrity: sha512-Qv7SXnRc0zq1kGXruNnSKpP3eFccXMR5Qv6GVX9hBIJ5efN0PflKPq92aQ5Cv3jrjJeRevLznWZVz7bttXhVfw==}
     engines: {node: ^12.0.0 || ^14.0.0 || ^16.0.0}
     hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
     dependencies:
-      '@ethereumjs/block': 3.6.1
-      '@ethereumjs/blockchain': 5.5.1
-      '@ethereumjs/common': 2.6.2
-      '@ethereumjs/tx': 3.5.0
-      '@ethereumjs/vm': 5.7.1
+      '@ethereumjs/block': 3.6.2
+      '@ethereumjs/blockchain': 5.5.3
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/tx': 3.5.2
+      '@ethereumjs/vm': 5.9.2
       '@ethersproject/abi': 5.6.0
       '@metamask/eth-sig-util': 4.0.0
       '@sentry/node': 5.30.0
@@ -8203,14 +8146,14 @@ packages:
       aggregate-error: 3.1.0
       ansi-escapes: 4.3.2
       chalk: 2.4.2
-      chokidar: 3.4.3
+      chokidar: 3.5.3
       ci-info: 2.0.0
-      debug: 4.3.2
+      debug: 4.3.3
       enquirer: 2.3.6
       env-paths: 2.2.1
       ethereum-cryptography: 0.1.3
       ethereumjs-abi: 0.6.8
-      ethereumjs-util: 7.1.4
+      ethereumjs-util: 7.1.5
       find-up: 2.1.0
       fp-ts: 1.19.3
       fs-extra: 7.0.1
@@ -8218,7 +8161,7 @@ packages:
       immutable: 4.0.0
       io-ts: 1.10.4
       lodash: 4.17.21
-      merkle-patricia-tree: 4.2.3
+      merkle-patricia-tree: 4.2.4
       mnemonist: 0.38.5
       mocha: 9.2.2
       p-map: 4.0.0
@@ -8227,12 +8170,12 @@ packages:
       resolve: 1.17.0
       semver: 6.3.0
       slash: 3.0.0
-      solc: 0.7.3_debug@4.3.2
+      solc: 0.7.3_debug@4.3.3
       source-map-support: 0.5.20
       stacktrace-parser: 0.1.10
       true-case-path: 2.2.1
       tsort: 0.0.1
-      undici: 4.15.1
+      undici: 5.4.0
       uuid: 8.3.2
       ws: 7.5.7
     transitivePeerDependencies:
@@ -8298,6 +8241,75 @@ packages:
       source-map-support: 0.5.20
       stacktrace-parser: 0.1.10
       true-case-path: 2.2.1
+      tsort: 0.0.1
+      typescript: 4.6.2
+      undici: 5.4.0
+      uuid: 8.3.2
+      ws: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /hardhat/2.9.9_ydznwdtnuvt5v5poxvazn5c734:
+    resolution: {integrity: sha512-Qv7SXnRc0zq1kGXruNnSKpP3eFccXMR5Qv6GVX9hBIJ5efN0PflKPq92aQ5Cv3jrjJeRevLznWZVz7bttXhVfw==}
+    engines: {node: ^12.0.0 || ^14.0.0 || ^16.0.0}
+    hasBin: true
+    peerDependencies:
+      ts-node: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@ethereumjs/block': 3.6.2
+      '@ethereumjs/blockchain': 5.5.3
+      '@ethereumjs/common': 2.6.4
+      '@ethereumjs/tx': 3.5.2
+      '@ethereumjs/vm': 5.9.2
+      '@ethersproject/abi': 5.6.0
+      '@metamask/eth-sig-util': 4.0.0
+      '@sentry/node': 5.30.0
+      '@solidity-parser/parser': 0.14.1
+      '@types/bn.js': 5.1.0
+      '@types/lru-cache': 5.1.1
+      abort-controller: 3.0.0
+      adm-zip: 0.4.16
+      aggregate-error: 3.1.0
+      ansi-escapes: 4.3.2
+      chalk: 2.4.2
+      chokidar: 3.5.3
+      ci-info: 2.0.0
+      debug: 4.3.3
+      enquirer: 2.3.6
+      env-paths: 2.2.1
+      ethereum-cryptography: 0.1.3
+      ethereumjs-abi: 0.6.8
+      ethereumjs-util: 7.1.5
+      find-up: 2.1.0
+      fp-ts: 1.19.3
+      fs-extra: 7.0.1
+      glob: 7.2.0
+      immutable: 4.0.0
+      io-ts: 1.10.4
+      lodash: 4.17.21
+      merkle-patricia-tree: 4.2.4
+      mnemonist: 0.38.5
+      mocha: 9.2.2
+      p-map: 4.0.0
+      qs: 6.10.3
+      raw-body: 2.5.1
+      resolve: 1.17.0
+      semver: 6.3.0
+      slash: 3.0.0
+      solc: 0.7.3_debug@4.3.3
+      source-map-support: 0.5.20
+      stacktrace-parser: 0.1.10
+      true-case-path: 2.2.1
+      ts-node: 10.7.0_55hvwysvdsti7rc6ljwd3v4ani
       tsort: 0.0.1
       typescript: 4.6.2
       undici: 5.4.0
@@ -10233,7 +10245,7 @@ packages:
       yallist: 4.0.0
 
   /lru_map/0.3.3:
-    resolution: {integrity: sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=}
+    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
     dev: true
 
   /ltgt/2.1.3:
@@ -10394,17 +10406,6 @@ packages:
       readable-stream: 3.6.0
       rlp: 2.2.7
       semaphore: 1.1.0
-    dev: true
-
-  /merkle-patricia-tree/4.2.3:
-    resolution: {integrity: sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==}
-    dependencies:
-      '@types/levelup': 4.3.3
-      ethereumjs-util: 7.1.4
-      level-mem: 5.0.1
-      level-ws: 2.0.0
-      readable-stream: 3.6.0
-      semaphore-async-await: 1.5.1
     dev: true
 
   /merkle-patricia-tree/4.2.4:
@@ -12870,7 +12871,7 @@ packages:
     optional: true
 
   /semaphore-async-await/1.5.1:
-    resolution: {integrity: sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo=}
+    resolution: {integrity: sha512-b/ptP11hETwYWpeilHXXQiV5UJNJl7ZWWooKRE5eBIYWoom6dZ0SluCIdCtKycsMtZgKWE01/qAw6jblw1YVhg==}
     engines: {node: '>=4.1'}
     dev: true
 
@@ -13176,24 +13177,6 @@ packages:
       require-from-string: 2.0.2
       semver: 5.7.1
       tmp: 0.0.33
-    dev: true
-
-  /solc/0.7.3_debug@4.3.2:
-    resolution: {integrity: sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      command-exists: 1.2.9
-      commander: 3.0.2
-      follow-redirects: 1.14.9_debug@4.3.2
-      fs-extra: 0.30.0
-      js-sha3: 0.8.0
-      memorystream: 0.3.1
-      require-from-string: 2.0.2
-      semver: 5.7.1
-      tmp: 0.0.33
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /solc/0.7.3_debug@4.3.3:
@@ -14371,11 +14354,6 @@ packages:
 
   /underscore/1.9.1:
     resolution: {integrity: sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==}
-    dev: true
-
-  /undici/4.15.1:
-    resolution: {integrity: sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==}
-    engines: {node: '>=12.18'}
     dev: true
 
   /undici/5.4.0:


### PR DESCRIPTION
This PR adds a `dontOverrideCompile` setting, which defaults to `true` for JavaScript projects, and `false` otherwise.

In addition to that, it fixes a small bug in the `clean` override.