### PR TITLE
Bump minimum version of truffle

### DIFF
--- a/packages/target-truffle-v5/package.json
+++ b/packages/target-truffle-v5/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "typechain": "^8.0.0",
-    "truffle": "^5.0.0",
+    "truffle": "^5.5.19",
     "web3-core": "^1",
     "web3-eth-contract": "^1",
     "web3-utils": "^1",


### PR DESCRIPTION
This PR updates the Truffle dependency to use a minimum version of what is now the [latest one out](https://github.com/trufflesuite/truffle/releases/tag/v5.5.19), which uses a [later version of pouchdb](https://github.com/trufflesuite/truffle/pull/5188) incorporating a [fix](https://github.com/node-fetch/node-fetch/pull/1453) for a [high severity vulnerability](https://github.com/advisories/GHSA-r683-j2x4-v87g) in node-fetch.

Simply relying on the caret notation and running `npm audit fix` will not necessarily work, because that will lead to updating the version of web3 used in Truffle to its latest version, which included a breaking change on the patch release number which has not yet been [resolved](https://github.com/trufflesuite/truffle/pull/5177) to again bring Truffle's types back into consistency with web3's changed typings; Typescript compilation fails.

Increasing this minimum version, in this case, enhances security. 