### PR TITLE
fix: target-startket-test test:fix

### DIFF
--- a/packages/target-starknet-test/devnet.sh
+++ b/packages/target-starknet-test/devnet.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 
-image=shardlabs/starknet-devnet:0.2.1
+image=shardlabs/starknet-devnet:0.2.10
 
 if [ "$(uname)" == "Darwin" ]; then
     image="${image}-arm"

--- a/packages/target-starknet-test/package.json
+++ b/packages/target-starknet-test/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf dist contracts/* && rm -f tsconfig.build.tsbuildinfo && rm -rf build",
     "generate-types": "node ../typechain/dist/cli/cli.js --target=../target-starknet/dist/index.js --out-dir './types/' './example-abis/*.json'",
     "test-out": "pnpm generate-types && ../../node_modules/.bin/mocha --config ../../.mocharc.js",
-    "test": "concurrently -k './devnet.sh' 'yarn test:fast; docker stop devnet'",
+    "test": "concurrently -k './devnet.sh' 'pnpm test:fast; docker stop devnet'",
     "test:fast": "wait-on tcp:5050 && pnpm generate-types && ../../node_modules/.bin/mocha --config ../../.mocharc.js",
     "test:fix": "pnpm lint:fix && pnpm format:fix && pnpm test && pnpm typecheck"
   },


### PR DESCRIPTION
When trying to run the command `pnpm test:fix`, locally on my MAC M1, I had two issues;

1. My yarn is version 3 and requires the project to have a yarn.lock. As the typechain project run with pnpm I change the command yarn to pnpm.
2. The version of the image requested was `image=shardlabs/starknet-devnet:0.2.1` but it returns a not-found image when it adds the `-arm` at the end of the name. Changing it to explicitly `0.2.10` solves the issue.