### PR TITLE
feat: add support for custom extractAbi from target

### DIFF
--- a/packages/typechain/src/typechain/findTarget.ts
+++ b/packages/typechain/src/typechain/findTarget.ts
@@ -3,10 +3,9 @@ import _, { compact } from 'lodash'
 import { debug } from '../utils/debug'
 import { ensureAbsPath } from '../utils/files/ensureAbsPath'
 import { tryRequire } from '../utils/modules'
-import { Config, TypeChainTarget } from './types'
+import { FindChainTarget } from './types'
 
-export function findTarget(config: Config): TypeChainTarget {
-  const target = config.target
+export function findTarget(target: string): FindChainTarget {
   if (!target) {
     throw new Error(`Please provide --target parameter!`)
   }
@@ -21,7 +20,7 @@ export function findTarget(config: Config): TypeChainTarget {
 
   if (!moduleInfo || !moduleInfo.module.default) {
     throw new Error(
-      `Couldn't find ${config.target}. Tried loading: ${compact(possiblePaths).join(
+      `Couldn't find ${target}. Tried loading: ${compact(possiblePaths).join(
         ', ',
       )}.\nPerhaps you forgot to install @typechain/${target}?`,
     )
@@ -29,5 +28,9 @@ export function findTarget(config: Config): TypeChainTarget {
 
   debug('Plugin found at', moduleInfo.path)
 
-  return new moduleInfo.module.default(config)
+  const chainTarget = moduleInfo.module.default
+
+  chainTarget.extractAbi = moduleInfo.module.extractAbi
+
+  return chainTarget
 }

--- a/packages/typechain/src/typechain/io.ts
+++ b/packages/typechain/src/typechain/io.ts
@@ -3,9 +3,9 @@ import { isArray } from 'lodash'
 import { dirname, relative } from 'path'
 
 import { outputTransformers } from '../codegen/outputTransformers'
-import { extractAbi } from '../parser/abiParser'
+import { extractAbi as extractAbiDefault } from '../parser/abiParser'
 import { debug } from '../utils/debug'
-import { Config, FileDescription, Output, Services } from './types'
+import { Config, ExtractAbiFunction, FileDescription, Output, Services } from './types'
 
 export function processOutput(services: Services, cfg: Config, output: Output): number {
   const { fs, mkdirp } = services
@@ -39,10 +39,10 @@ export function loadFileDescriptions(services: Services, files: string[]): FileD
   return fileDescriptions
 }
 
-export function skipEmptyAbis(paths: string[]): string[] {
+export function skipEmptyAbis(paths: string[], extractAbi?: ExtractAbiFunction): string[] {
   const notEmptyAbis = paths
     .map((p) => ({ path: p, contents: readFileSync(p, 'utf-8') }))
-    .filter((fd) => extractAbi(fd.contents).length !== 0)
+    .filter((fd) => (extractAbi || extractAbiDefault)(fd.contents).length !== 0)
 
   return notEmptyAbis.map((p) => p.path)
 }

--- a/packages/typechain/src/typechain/runTypeChain.ts
+++ b/packages/typechain/src/typechain/runTypeChain.ts
@@ -21,7 +21,8 @@ export const DEFAULT_FLAGS: CodegenConfig = {
 }
 
 export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> {
-  const allFiles = skipEmptyAbis(publicConfig.allFiles)
+  const ChainTarget = findTarget(publicConfig.target)
+  const allFiles = skipEmptyAbis(publicConfig.allFiles, ChainTarget.extractAbi)
 
   // skip empty paths
   const config: Config = {
@@ -29,7 +30,7 @@ export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> 
     inputDir: detectInputsRoot(allFiles),
     ...publicConfig,
     allFiles,
-    filesToProcess: skipEmptyAbis(publicConfig.filesToProcess),
+    filesToProcess: skipEmptyAbis(publicConfig.filesToProcess, ChainTarget.extractAbi),
   }
   const services: Services = {
     fs,
@@ -38,7 +39,7 @@ export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> 
   }
   let filesGenerated = 0
 
-  const target = findTarget(config)
+  const target = new ChainTarget(config)
 
   const fileDescriptions = loadFileDescriptions(services, config.filesToProcess)
 

--- a/packages/typechain/src/typechain/types.ts
+++ b/packages/typechain/src/typechain/types.ts
@@ -3,6 +3,8 @@ import { sync as mkdirp } from 'mkdirp'
 import * as prettier from 'prettier'
 import { MarkOptional } from 'ts-essentials'
 
+import { RawAbiDefinition } from '../parser/abiParser'
+
 export interface Config {
   cwd: string
   target: string
@@ -27,6 +29,10 @@ export interface CodegenConfig {
 }
 
 export type PublicConfig = MarkOptional<Config, 'flags' | 'inputDir'>
+
+export type ExtractAbiFunction = (rawJson: string) => RawAbiDefinition[]
+
+export type FindChainTarget = { new (...args: any[]): TypeChainTarget; extractAbi?: ExtractAbiFunction }
 
 export abstract class TypeChainTarget {
   public abstract readonly name: string


### PR DESCRIPTION
## Problem

Currently on [fuels-ts](https://github.com/FuelLabs/fuels-ts) a TS SDK for Fuel. We enable users to generate contract types using our `typechain-target-fuels`. Recently we have implemented a flat `ABI.json` model, that is not a valid Ether ABI.

But when running `runTypeChain` by CI or API, the implementation on `typechain` executes an `extractAbi` method to filter empty ABI files ([see file line in typechain](https://github.com/dethcrypto/TypeChain/blob/92faf28a91fa17a6cb9c34bd29ea9b2cae5d57b3/packages/typechain/src/typechain/io.ts#L42)). The current way it's implementated is impossible for the Target, to implement a custom `extractAbi`.

## Solution

The proposed solution for this use case is to enable the TypeChainTarget to also export `extractAbi` function wich will replace the `extractAbi`, on the `skipEmptyAbis`.

```ts
export const extractAbi = (rawJson: string) => myCustomExtractAbi(rawJson);

export default class MyCustomTarget extends TypeChainTarget {
  .....
}
```