### PR TITLE
[Hardhat plugin] Don't import libraries until they are needed

### DIFF
--- a/.changeset/light-hairs-chew.md
+++ b/.changeset/light-hairs-chew.md
@@ -1,0 +1,5 @@
+---
+"@typechain/hardhat": patch
+---
+
+Reduce the time it takes to load the plugin by importing every library only when needed

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -30,8 +30,7 @@
     "test:fix": "pnpm lint:fix && pnpm format:fix && pnpm test && pnpm typecheck"
   },
   "dependencies": {
-    "fs-extra": "^9.1.0",
-    "lodash": "^4.17.15"
+    "fs-extra": "^9.1.0"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.4.7",
@@ -39,7 +38,6 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@typechain/ethers-v5": "workspace:^10.1.0",
     "@types/fs-extra": "^9.0.7",
-    "@types/lodash": "^4.14.139",
     "@types/rimraf": "^3.0.0",
     "ethers": "^5.4.7",
     "hardhat": "^2.9.9",

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -5,7 +5,7 @@ import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'ha
 import { extendConfig, subtask, task, types } from 'hardhat/config'
 import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
 import _, { uniq } from 'lodash'
-import { glob, PublicConfig as RunTypeChainConfig, runTypeChain } from 'typechain'
+import type { PublicConfig as RunTypeChainConfig } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
 import { TASK_TYPECHAIN, TASK_TYPECHAIN_GENERATE_TYPES } from './constants'
@@ -66,6 +66,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
     }
     const cwd = config.paths.root
 
+    const { glob } = await import('typechain')
     const allFiles = glob(cwd, [`${config.paths.artifacts}/!(build-info)/**/+([a-zA-Z0-9_]).json`])
     if (typechainCfg.externalArtifacts) {
       allFiles.push(...glob(cwd, typechainCfg.externalArtifacts, false))
@@ -84,6 +85,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
       },
     }
 
+    const { runTypeChain } = await import('typechain')
     const result = await runTypeChain({
       ...typechainOptions,
       filesToProcess: needsFullRebuild ? allFiles : glob(cwd, artifactPaths), // only process changed files if not doing full rebuild

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -1,6 +1,5 @@
 import './type-extensions'
 
-import fsExtra from 'fs-extra'
 import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
 import { extendConfig, subtask, task, types } from 'hardhat/config'
 import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
@@ -124,6 +123,7 @@ task(
       return runSuper()
     }
 
+    const fsExtra = await import('fs-extra')
     if (await fsExtra.pathExists(config.typechain.outDir)) {
       await fsExtra.remove(config.typechain.outDir)
     }

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -4,7 +4,6 @@ import fsExtra from 'fs-extra'
 import { TASK_CLEAN, TASK_COMPILE, TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
 import { extendConfig, subtask, task, types } from 'hardhat/config'
 import { getFullyQualifiedName } from 'hardhat/utils/contract-names'
-import _, { uniq } from 'lodash'
 import type { PublicConfig as RunTypeChainConfig } from 'typechain'
 
 import { getDefaultTypechainConfig } from './config'
@@ -38,7 +37,9 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
   .addFlag('quiet', 'Makes the process less verbose')
   .setAction(async ({ compileSolOutput, quiet }, { config, artifacts }) => {
     const artifactFQNs: string[] = getFQNamesFromCompilationOutput(compileSolOutput)
-    const artifactPaths = uniq(artifactFQNs.map((fqn) => artifacts.formArtifactPathFromFullyQualifiedName(fqn)))
+    const artifactPaths = Array.from(
+      new Set(artifactFQNs.map((fqn) => artifacts.formArtifactPathFromFullyQualifiedName(fqn))),
+    )
 
     if (taskArgsStore.noTypechain) {
       return compileSolOutput
@@ -140,5 +141,5 @@ function getFQNamesFromCompilationOutput(compileSolOutput: any): string[] {
     })
   })
 
-  return _(allFQNNamesNested).flatten().flatten().value()
+  return allFQNNamesNested.flat(2)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,25 +217,21 @@ importers:
       '@nomiclabs/hardhat-ethers': ^2.0.2
       '@typechain/ethers-v5': workspace:^10.1.0
       '@types/fs-extra': ^9.0.7
-      '@types/lodash': ^4.14.139
       '@types/rimraf': ^3.0.0
       ethers: ^5.4.7
       fs-extra: ^9.1.0
       hardhat: ^2.9.9
-      lodash: ^4.17.15
       rimraf: ^3.0.2
       typechain: workspace:^8.1.0
       typescript: ^4
     dependencies:
       fs-extra: 9.1.0
-      lodash: 4.17.21
     devDependencies:
       '@ethersproject/abi': 5.6.0
       '@ethersproject/providers': 5.6.0
       '@nomiclabs/hardhat-ethers': 2.0.5_ethers@5.6.0+hardhat@2.9.9
       '@typechain/ethers-v5': link:../target-ethers-v5
       '@types/fs-extra': 9.0.13
-      '@types/lodash': 4.14.179
       '@types/rimraf': 3.0.2
       ethers: 5.6.0
       hardhat: 2.9.9_typescript@4.6.2
@@ -14287,7 +14283,6 @@ packages:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /typewise-core/1.2.0:
     resolution: {integrity: sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=}


### PR DESCRIPTION
Hey @krzkaczor,

Just a quick PR optimizing this plugin. This makes projects using it run faster in general. You can appreciate the difference if you run a `npx hardhat --help` in a project using this version of the plugin and `latest`.

The difference is not huge, but it compounds with other plugins, so I'm doing this for every plugin included in the hardhat toolbox.

Also, I don't think lodash is needed anymore, so I removed it.