### PR TITLE
Fix the `lowestCommonPath` function, by stopping at first different sub-path

### DIFF
--- a/.changeset/ten-pants-learn.md
+++ b/.changeset/ten-pants-learn.md
@@ -1,0 +1,5 @@
+---
+'typechain': patch
+---
+
+Fix the detection of inputs root in some specific scenarios

--- a/packages/typechain/src/utils/files/lowestCommonPath.ts
+++ b/packages/typechain/src/utils/files/lowestCommonPath.ts
@@ -1,5 +1,14 @@
 export function lowestCommonPath(paths: string[]) {
   const pathParts = paths.map((path) => path.split(/[\\/]/))
-  const commonParts = pathParts[0].filter((part, index) => pathParts.every((parts) => parts[index] === part))
+  const commonParts = [] as string[];
+  const maxParts = Math.min.apply(null, pathParts.map(p => p.length));
+  for (let i = 0; i < maxParts; i++) {
+    const part = pathParts[0][i];
+    if (pathParts.slice(1).every((otherPath) => otherPath[i] === part)) {
+      commonParts.push(part)
+    } else {
+      break;
+    }
+  }
   return commonParts.join('/')
 }

--- a/packages/typechain/test/utils/files/lowestCommonPath.test.ts
+++ b/packages/typechain/test/utils/files/lowestCommonPath.test.ts
@@ -18,6 +18,16 @@ describe(lowestCommonPath.name, () => {
     expect(actual).toEqual('/TypeChain/contracts/compiled')
   })
 
+  it('stops at first different sub-path', () => {
+    const paths = [
+      '/TypeChain/contracts/v0.6.4/interfaces/Payable.abi',
+      '/TypeChain/contracts/v0.8.9/interfaces/Rarity.abi',
+    ]
+
+    const actual = lowestCommonPath(paths)
+    expect(actual).toEqual('/TypeChain/contracts')
+  })
+
   it('works for Windows paths', () => {
     const paths = [
       'D:/workspace/TypeChain/packages/hardhat/test/fixture-projects/hardhat-project/artifacts/contracts/EdgeCases.sol/EdgeCases.json',


### PR DESCRIPTION
This fixes issue #772 