### PR TITLE
Update the compile-contracts scripts to allow newer fixed NPX versions

### DIFF
--- a/scripts/compile-contracts.ts
+++ b/scripts/compile-contracts.ts
@@ -24,7 +24,7 @@ main()
 
 function panicOnNpm7() {
   const version = new SemVer(execSync('npm -v', { encoding: 'utf8' }).trim())
-  if (version.major > 6) {
+  if (version.major > 6 && (version.major < 8 && version.minor < 16)) {
     console.error(
       '\n' +
         `We're sorry, but it seems you are using ${bold('NPM ' + version.format())}.\n` +


### PR DESCRIPTION
The known bug with npm versions above 6 has been fixed in 8.16.x. This allows newer npm(x) versions to run more easily on the m1 arm chips.