### PR TITLE
Add struct parsing to @typechain/web3-v1

### DIFF
--- a/.changeset/pink-ads-rhyme.md
+++ b/.changeset/pink-ads-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@typechain/web3-v1': minor
+---
+
+Add struct parsing and typing for web3 library

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
@@ -21,6 +21,46 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace StructsLib1 {
+  export type InfoStruct =
+    | [number | string | BN, number | string | BN]
+    | { a: number | string | BN; b: number | string | BN };
+
+  export type InfoStructOutput = [string, string] & { a: string; b: string };
+}
+
+export declare namespace StructsLib2 {
+  export type InfoStruct = [string, string] | { a: string; b: string };
+
+  export type InfoStructOutput = [string, string] & { a: string; b: string };
+}
+
+export declare namespace DataTypesInput {
+  export type Struct1Struct =
+    | [number | string | BN, number | string | BN]
+    | { uint256_0: number | string | BN; uint256_1: number | string | BN };
+
+  export type Struct1StructOutput = [string, string] & {
+    uint256_0: string;
+    uint256_1: string;
+  };
+
+  export type Struct2Struct =
+    | [number | string | BN, DataTypesInput.Struct1Struct]
+    | { input1: number | string | BN; input2: DataTypesInput.Struct1Struct };
+
+  export type Struct2StructOutput = [
+    string,
+    DataTypesInput.Struct1StructOutput
+  ] & { input1: string; input2: DataTypesInput.Struct1StructOutput };
+
+  export type Struct3Struct =
+    | [number | string | BN[]]
+    | { input1: number | string | BN[] };
+
+  export type Struct3StructOutput = [string[]] & { input1: string[] };
+}
+
 export interface DataTypesInput extends BaseContract {
   constructor(
     jsonInterface: any[],
@@ -44,8 +84,20 @@ export interface DataTypesInput extends BaseContract {
     ): NonPayableTransactionObject<string>;
 
     input_fixedarray_array_fixedarray(
-      input1: (number | string | BN)[][][]
-    ): NonPayableTransactionObject<string[][][]>;
+      input1: [
+        [number | string | BN, number | string | BN, number | string | BN][],
+        [number | string | BN, number | string | BN, number | string | BN][],
+        [number | string | BN, number | string | BN, number | string | BN][],
+        [number | string | BN, number | string | BN, number | string | BN][]
+      ]
+    ): NonPayableTransactionObject<
+      [
+        [string, string, string][],
+        [string, string, string][],
+        [string, string, string][],
+        [string, string, string][]
+      ]
+    >;
 
     input_int256(
       input1: number | string | BN
@@ -56,83 +108,203 @@ export interface DataTypesInput extends BaseContract {
     ): NonPayableTransactionObject<string>;
 
     input_multiple_structs_with_same_name(
-      info1: [number | string | BN, number | string | BN]
-    ): NonPayableTransactionObject<[string, string]>;
+      info1: StructsLib1.InfoStruct
+    ): NonPayableTransactionObject<StructsLib2.InfoStructOutput>;
 
     input_stat_array(
-      input1: (number | string | BN)[]
-    ): NonPayableTransactionObject<string[]>;
+      input1: [number | string | BN, number | string | BN, number | string | BN]
+    ): NonPayableTransactionObject<[string, string, string]>;
 
     input_string(input1: string): NonPayableTransactionObject<string>;
 
     input_struct(
-      input1: [number | string | BN, number | string | BN]
-    ): NonPayableTransactionObject<[string, string]>;
+      input1: DataTypesInput.Struct1Struct
+    ): NonPayableTransactionObject<DataTypesInput.Struct1StructOutput>;
 
     input_struct2(
-      input1: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
-      ]
-    ): NonPayableTransactionObject<[string, [string, string]]>;
+      input1: DataTypesInput.Struct2Struct
+    ): NonPayableTransactionObject<DataTypesInput.Struct2StructOutput>;
 
     input_struct2_array(
-      input1: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
-      ][]
-    ): NonPayableTransactionObject<[string, [string, string]][]>;
+      input1: DataTypesInput.Struct2Struct[]
+    ): NonPayableTransactionObject<DataTypesInput.Struct2StructOutput[]>;
 
     input_struct2_tuple(
       input: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
-      ][]
-    ): NonPayableTransactionObject<[string, [string, string]][]>;
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct,
+        DataTypesInput.Struct2Struct
+      ]
+    ): NonPayableTransactionObject<
+      [
+        DataTypesInput.Struct2StructOutput,
+        DataTypesInput.Struct2StructOutput,
+        DataTypesInput.Struct2StructOutput
+      ]
+    >;
 
     input_struct3_array(
-      input1: [(number | string | BN)[]][]
-    ): NonPayableTransactionObject<[string[]][]>;
+      input1: DataTypesInput.Struct3Struct[]
+    ): NonPayableTransactionObject<DataTypesInput.Struct3StructOutput[]>;
 
     input_struct_array(
-      input1: [number | string | BN, number | string | BN][]
-    ): NonPayableTransactionObject<[string, string][]>;
+      input1: DataTypesInput.Struct1Struct[]
+    ): NonPayableTransactionObject<DataTypesInput.Struct1StructOutput[]>;
 
     input_struct_array_array(
-      input1: [number | string | BN, number | string | BN][][]
-    ): NonPayableTransactionObject<[string, string][][]>;
+      input1: DataTypesInput.Struct1Struct[][]
+    ): NonPayableTransactionObject<DataTypesInput.Struct1StructOutput[][]>;
 
     input_struct_array_array_array(
-      input1: [number | string | BN, number | string | BN][][][]
-    ): NonPayableTransactionObject<[string, string][][][]>;
+      input1: DataTypesInput.Struct1Struct[][][]
+    ): NonPayableTransactionObject<DataTypesInput.Struct1StructOutput[][][]>;
 
     input_struct_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][]
-    ): NonPayableTransactionObject<[string, string][][]>;
+      input1: [DataTypesInput.Struct1Struct[], DataTypesInput.Struct1Struct[]]
+    ): NonPayableTransactionObject<
+      [
+        DataTypesInput.Struct1StructOutput[],
+        DataTypesInput.Struct1StructOutput[]
+      ]
+    >;
 
     input_struct_fixedarray_array(
-      input1: [number | string | BN, number | string | BN][][]
-    ): NonPayableTransactionObject<[string, string][][]>;
+      input1: [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+    ): NonPayableTransactionObject<
+      [DataTypesInput.Struct1StructOutput, DataTypesInput.Struct1StructOutput][]
+    >;
 
     input_struct_fixedarray_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][][]
-    ): NonPayableTransactionObject<[string, string][][][]>;
+      input1: [
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+      ]
+    ): NonPayableTransactionObject<
+      [
+        [
+          DataTypesInput.Struct1StructOutput,
+          DataTypesInput.Struct1StructOutput
+        ][],
+        [
+          DataTypesInput.Struct1StructOutput,
+          DataTypesInput.Struct1StructOutput
+        ][],
+        [
+          DataTypesInput.Struct1StructOutput,
+          DataTypesInput.Struct1StructOutput
+        ][]
+      ]
+    >;
 
     input_struct_fixedarray_array_fixedarray_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][][][][]
-    ): NonPayableTransactionObject<[string, string][][][][][]>;
+      input1: [
+        [
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+        ][],
+        [
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+        ][],
+        [
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+        ][],
+        [
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][],
+          [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct][]
+        ][]
+      ]
+    ): NonPayableTransactionObject<
+      [
+        [
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][]
+        ][],
+        [
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][]
+        ][],
+        [
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][]
+        ][],
+        [
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][],
+          [
+            DataTypesInput.Struct1StructOutput,
+            DataTypesInput.Struct1StructOutput
+          ][]
+        ][]
+      ]
+    >;
 
     input_struct_fixedarray_fixedarray(
-      input1: [number | string | BN, number | string | BN][][]
-    ): NonPayableTransactionObject<[string, string][][]>;
+      input1: [
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct],
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct],
+        [DataTypesInput.Struct1Struct, DataTypesInput.Struct1Struct]
+      ]
+    ): NonPayableTransactionObject<
+      [
+        [
+          DataTypesInput.Struct1StructOutput,
+          DataTypesInput.Struct1StructOutput
+        ],
+        [
+          DataTypesInput.Struct1StructOutput,
+          DataTypesInput.Struct1StructOutput
+        ],
+        [DataTypesInput.Struct1StructOutput, DataTypesInput.Struct1StructOutput]
+      ]
+    >;
 
     input_tuple(
       input1: number | string | BN,
       input2: number | string | BN
-    ): NonPayableTransactionObject<{
-      0: string;
-      1: string;
-    }>;
+    ): NonPayableTransactionObject<[string, string]>;
 
     input_uint256(
       input1: number | string | BN
@@ -143,7 +315,7 @@ export interface DataTypesInput extends BaseContract {
     ): NonPayableTransactionObject<string>;
 
     input_uint_array(
-      input1: (number | string | BN)[]
+      input1: number | string | BN[]
     ): NonPayableTransactionObject<string[]>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
@@ -21,6 +21,17 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace DataTypesPure {
+  export type Struct1Struct =
+    | [number | string | BN, number | string | BN]
+    | { uint256_0: number | string | BN; uint256_1: number | string | BN };
+
+  export type Struct1StructOutput = [string, string] & {
+    uint256_0: string;
+    uint256_1: string;
+  };
+}
+
 export interface DataTypesPure extends BaseContract {
   constructor(
     jsonInterface: any[],
@@ -43,23 +54,17 @@ export interface DataTypesPure extends BaseContract {
 
     pure_int8(): NonPayableTransactionObject<string>;
 
-    pure_named(): NonPayableTransactionObject<{
-      uint256_1: string;
-      uint256_2: string;
-      0: string;
-      1: string;
-    }>;
+    pure_named(): NonPayableTransactionObject<
+      [string, string] & { uint256_1: string; uint256_2: string }
+    >;
 
-    pure_stat_array(): NonPayableTransactionObject<string[]>;
+    pure_stat_array(): NonPayableTransactionObject<[string, string, string]>;
 
     pure_string(): NonPayableTransactionObject<string>;
 
-    pure_struct(): NonPayableTransactionObject<[string, string]>;
+    pure_struct(): NonPayableTransactionObject<DataTypesPure.Struct1StructOutput>;
 
-    pure_tuple(): NonPayableTransactionObject<{
-      0: string;
-      1: string;
-    }>;
+    pure_tuple(): NonPayableTransactionObject<[string, string]>;
 
     pure_uint256(): NonPayableTransactionObject<string>;
 

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
@@ -21,6 +21,17 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace DataTypesView {
+  export type Struct1Struct =
+    | [number | string | BN, number | string | BN]
+    | { uint256_0: number | string | BN; uint256_1: number | string | BN };
+
+  export type Struct1StructOutput = [string, string] & {
+    uint256_0: string;
+    uint256_1: string;
+  };
+}
+
 export interface DataTypesView extends BaseContract {
   constructor(
     jsonInterface: any[],
@@ -43,23 +54,17 @@ export interface DataTypesView extends BaseContract {
 
     view_int8(): NonPayableTransactionObject<string>;
 
-    view_named(): NonPayableTransactionObject<{
-      uint256_1: string;
-      uint256_2: string;
-      0: string;
-      1: string;
-    }>;
+    view_named(): NonPayableTransactionObject<
+      [string, string] & { uint256_1: string; uint256_2: string }
+    >;
 
-    view_stat_array(): NonPayableTransactionObject<string[]>;
+    view_stat_array(): NonPayableTransactionObject<[string, string, string]>;
 
     view_string(): NonPayableTransactionObject<string>;
 
-    view_struct(): NonPayableTransactionObject<[string, string]>;
+    view_struct(): NonPayableTransactionObject<DataTypesView.Struct1StructOutput>;
 
-    view_tuple(): NonPayableTransactionObject<{
-      0: string;
-      1: string;
-    }>;
+    view_tuple(): NonPayableTransactionObject<[string, string]>;
 
     view_uint256(): NonPayableTransactionObject<string>;
 

--- a/packages/target-web3-v1-test/types/v0.6.4/Events.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Events.ts
@@ -21,6 +21,17 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace Events {
+  export type EventDataStruct =
+    | [number | string | BN, string]
+    | { index: number | string | BN; name: string };
+
+  export type EventDataStructOutput = [string, string] & {
+    index: string;
+    name: string;
+  };
+}
+
 export type AnonEvent1 = ContractEventLog<{
   value1: string;
   0: string;
@@ -45,8 +56,8 @@ export type Event3_uint256 = ContractEventLog<{
   0: string;
 }>;
 export type Event4 = ContractEventLog<{
-  data: [string, string];
-  0: [string, string];
+  data: Events.EventDataStructOutput;
+  0: Events.EventDataStructOutput;
 }>;
 export type NoArgsEvent = ContractEventLog<{}>;
 export type UpdateFrequencySet = ContractEventLog<{

--- a/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
@@ -21,6 +21,34 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace Issue552_Observer {
+  export type ObservationStruct =
+    | [number | string | BN, number | string | BN]
+    | { val: number | string | BN; blockTimestamp: number | string | BN };
+
+  export type ObservationStructOutput = [string, string] & {
+    val: string;
+    blockTimestamp: string;
+  };
+}
+
+export declare namespace Issue552_Reproduction {
+  export type ObservationParamsStruct =
+    | [Issue552_Observer.ObservationStruct[], number | string | BN]
+    | {
+        observations: Issue552_Observer.ObservationStruct[];
+        index: number | string | BN;
+      };
+
+  export type ObservationParamsStructOutput = [
+    Issue552_Observer.ObservationStructOutput[],
+    string
+  ] & {
+    observations: Issue552_Observer.ObservationStructOutput[];
+    index: string;
+  };
+}
+
 export interface Issue552_Reproduction extends BaseContract {
   constructor(
     jsonInterface: any[],
@@ -31,9 +59,9 @@ export interface Issue552_Reproduction extends BaseContract {
   methods: {
     bars(
       arg0: number | string | BN
-    ): NonPayableTransactionObject<[[string, string][], string]>;
+    ): NonPayableTransactionObject<Issue552_Reproduction.ObservationParamsStructOutput>;
 
-    input(values: (number | string | BN)[]): NonPayableTransactionObject<void>;
+    input(values: number | string | BN[]): NonPayableTransactionObject<void>;
 
     makeObservation(
       barId: number | string | BN,

--- a/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
@@ -21,9 +21,20 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export declare namespace KingOfTheHill {
+  export type BidStruct =
+    | [string, number | string | BN]
+    | { bidder: string; value: number | string | BN };
+
+  export type BidStructOutput = [string, string] & {
+    bidder: string;
+    value: string;
+  };
+}
+
 export type HighestBidIncreased = ContractEventLog<{
-  bid: [string, string];
-  0: [string, string];
+  bid: KingOfTheHill.BidStructOutput;
+  0: KingOfTheHill.BidStructOutput;
 }>;
 
 export interface KingOfTheHill extends BaseContract {
@@ -36,12 +47,9 @@ export interface KingOfTheHill extends BaseContract {
   methods: {
     bid(): PayableTransactionObject<void>;
 
-    highestBid(): NonPayableTransactionObject<{
-      bidder: string;
-      value: string;
-      0: string;
-      1: string;
-    }>;
+    highestBid(): NonPayableTransactionObject<
+      [string, string] & { bidder: string; value: string }
+    >;
 
     withdraw(): NonPayableTransactionObject<void>;
   };

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
@@ -133,16 +133,16 @@ export interface Rarity extends BaseContract {
 
     summon(_class: number | string | BN): NonPayableTransactionObject<void>;
 
-    summoner(_summoner: number | string | BN): NonPayableTransactionObject<{
-      _xp: string;
-      _log: string;
-      _class: string;
-      _level: string;
-      0: string;
-      1: string;
-      2: string;
-      3: string;
-    }>;
+    summoner(
+      _summoner: number | string | BN
+    ): NonPayableTransactionObject<
+      [string, string, string, string] & {
+        _xp: string;
+        _log: string;
+        _class: string;
+        _level: string;
+      }
+    >;
 
     tokenByIndex(
       index: number | string | BN

--- a/packages/target-web3-v1/src/codegen/events.ts
+++ b/packages/target-web3-v1/src/codegen/events.ts
@@ -73,7 +73,7 @@ function codegenEventDeclaration(event: EventDeclaration, overloadedName?: strin
 
 function codegenOutputTypesForEvents(outputs: EventArgDeclaration[]): string {
   return `{
-    ${outputs.map((t) => t.name && `${t.name}: ${codegenOutputType(t.type)}, `).join('')}
-    ${outputs.map((t, i) => `${i}: ${codegenOutputType(t.type)}`).join(', ')}
+    ${outputs.map((t) => t.name && `${t.name}: ${codegenOutputType({ useStructs: true }, t.type)}, `).join('')}
+    ${outputs.map((t, i) => `${i}: ${codegenOutputType({ useStructs: true }, t.type)}`).join(', ')}
   }`
 }

--- a/packages/target-web3-v1/src/codegen/index.ts
+++ b/packages/target-web3-v1/src/codegen/index.ts
@@ -1,9 +1,11 @@
-import { Contract } from 'typechain'
+import { values } from 'lodash'
+import { CodegenConfig, Contract } from 'typechain'
 
 import { codegenForEvents, codegenForEventsDeclarations, codegenForEventsOnceFns } from './events'
 import { codegenForFunctions } from './functions'
+import { generateStructTypes } from './structs'
 
-export function codegen(contract: Contract) {
+export function codegen(contract: Contract, codegenConfig: CodegenConfig) {
   const typesPath = contract.path.length ? `${new Array(contract.path.length).fill('..').join('/')}/types` : './types'
 
   const template = `
@@ -19,13 +21,15 @@ export function codegen(contract: Contract) {
     topics?: string[];
   }
 
+  ${generateStructTypes(values(contract.structs).map((v) => v[0]))}
+
   ${codegenForEventsDeclarations(contract.events)}
 
   export interface ${contract.name} extends BaseContract {
     constructor(jsonInterface: any[], address?: string, options?: ContractOptions): ${contract.name};
     clone(): ${contract.name};
     methods: {
-      ${codegenForFunctions(contract.functions)}
+      ${codegenForFunctions(contract.functions, { codegenConfig })}
     };
     events: {
       ${codegenForEvents(contract.events)}

--- a/packages/target-web3-v1/src/codegen/structs.ts
+++ b/packages/target-web3-v1/src/codegen/structs.ts
@@ -1,0 +1,42 @@
+import { groupBy } from 'lodash'
+import { StructName, StructType } from 'typechain'
+
+import { STRUCT_INPUT_POSTFIX, STRUCT_OUTPUT_POSTFIX } from '../common'
+import { codegenInputType, codegenOutputType } from './types'
+
+export function generateStructTypes(structs: StructType[]) {
+  const namedStructs = structs.filter((s): s is StructWithName => !!s.structName)
+  const namespaces = groupBy(namedStructs, (s) => s.structName.namespace)
+
+  const exports: string[] = []
+
+  if ('undefined' in namespaces) {
+    exports.push(namespaces['undefined'].map((s) => generateExports(s)).join('\n'))
+    delete namespaces['undefined']
+  }
+
+  for (const namespace of Object.keys(namespaces)) {
+    exports.push(`\nexport declare namespace ${namespace} {
+      ${namespaces[namespace].map((s) => generateExports(s)).join('\n')}
+    }`)
+  }
+
+  return exports.join('\n')
+}
+
+function generateExports(struct: StructWithName): string {
+  const { identifier } = struct.structName
+
+  const inputName = `${identifier}${STRUCT_INPUT_POSTFIX}`
+  const outputName = `${identifier}${STRUCT_OUTPUT_POSTFIX}`
+  const inputType = codegenInputType({ useStructs: false }, struct)
+  const outputType = codegenOutputType({ useStructs: false }, struct)
+
+  return `
+    export type ${inputName} = ${inputType}
+
+    export type ${outputName} = ${outputType}
+  `
+}
+
+type StructWithName = StructType & { structName: StructName }

--- a/packages/target-web3-v1/src/codegen/structs.ts
+++ b/packages/target-web3-v1/src/codegen/structs.ts
@@ -29,13 +29,19 @@ function generateExports(struct: StructWithName): string {
 
   const inputName = `${identifier}${STRUCT_INPUT_POSTFIX}`
   const outputName = `${identifier}${STRUCT_OUTPUT_POSTFIX}`
+  const outputNameArray = `${outputName}Array`;
+  const outputNameObject = `${outputName}Struct`;
   const inputType = codegenInputType({ useStructs: false }, struct)
   const outputType = codegenOutputType({ useStructs: false }, struct)
+
+  const [outputTypeArray,outputTypeObject] = outputType.split('&');
 
   return `
     export type ${inputName} = ${inputType}
 
-    export type ${outputName} = ${outputType}
+    export type ${outputNameArray} = ${outputTypeArray}
+    export type ${outputNameObject} = ${outputTypeObject}
+    export type ${outputName} = ${outputNameArray} & ${outputNameObject}
   `
 }
 

--- a/packages/target-web3-v1/src/codegen/types.ts
+++ b/packages/target-web3-v1/src/codegen/types.ts
@@ -1,26 +1,32 @@
+import { compact } from 'lodash'
 import { AbiOutputParameter, AbiParameter, EvmOutputType, EvmType, TupleType } from 'typechain'
 
-export function codegenInputTypes(input: AbiParameter[]): string {
+import { STRUCT_INPUT_POSTFIX, STRUCT_OUTPUT_POSTFIX } from '../common'
+
+interface GenerateTypeOptions {
+  returnResultObject?: boolean
+  useStructs?: boolean // uses struct type for first depth, if false then generates first depth tuple types
+}
+
+export function codegenInputTypes(options: GenerateTypeOptions, input: Array<AbiParameter>): string {
   if (input.length === 0) {
     return ''
   }
   return (
-    input.map((input, index) => `${input.name || `arg${index}`}: ${codegenInputType(input.type)}`).join(', ') + ', '
+    input.map((input, index) => `${input.name || `arg${index}`}: ${codegenInputType(options, input.type)}`).join(', ') +
+    ', '
   )
 }
 
-export function codegenOutputTypes(outputs: AbiOutputParameter[]): string {
-  if (outputs.length === 1) {
-    return codegenOutputType(outputs[0].type)
+export function codegenOutputTypes(options: GenerateTypeOptions, outputs: Array<AbiOutputParameter>): string {
+  if (!options.returnResultObject && outputs.length === 1) {
+    return codegenOutputType(options, outputs[0].type)
   } else {
-    return `{
-      ${outputs.map((t) => t.name && `${t.name}: ${codegenOutputType(t.type)}, `).join('')}
-      ${outputs.map((t, i) => `${i}: ${codegenOutputType(t.type)}`).join(', ')}
-    }`
+    return codegenOutputComplexType(outputs, options)
   }
 }
 
-export function codegenInputType(evmType: EvmType): string {
+export function codegenInputType(options: GenerateTypeOptions, evmType: EvmType): string {
   switch (evmType.type) {
     case 'integer':
     case 'uinteger':
@@ -31,19 +37,22 @@ export function codegenInputType(evmType: EvmType): string {
     case 'dynamic-bytes':
       return 'string | number[]'
     case 'array':
-      return `(${codegenInputType(evmType.itemType)})[]`
+      return codegenArrayOrTupleType(codegenInputType(options, evmType.itemType), evmType.size)
     case 'boolean':
       return 'boolean'
     case 'string':
       return 'string'
     case 'tuple':
-      return codegenTupleType(evmType, codegenInputType)
+      if (evmType.structName && options.useStructs) {
+        return evmType.structName.toString() + STRUCT_INPUT_POSTFIX
+      }
+      return codegenInputComplexType(evmType.components, { ...options, useStructs: true })
     case 'unknown':
       return 'any'
   }
 }
 
-export function codegenOutputType(evmType: EvmOutputType): string {
+export function codegenOutputType(options: GenerateTypeOptions, evmType: EvmOutputType): string {
   switch (evmType.type) {
     case 'integer':
       return 'string'
@@ -57,18 +66,88 @@ export function codegenOutputType(evmType: EvmOutputType): string {
     case 'dynamic-bytes':
       return 'string'
     case 'array':
-      return `(${codegenOutputType(evmType.itemType)})[]`
+      return codegenArrayOrTupleType(codegenOutputType(options, evmType.itemType), evmType.size)
     case 'boolean':
       return 'boolean'
     case 'string':
       return 'string'
     case 'tuple':
-      return codegenTupleType(evmType, codegenOutputType)
+      if (evmType.structName && options.useStructs) {
+        return evmType.structName.toString() + STRUCT_OUTPUT_POSTFIX
+      }
+      return codegenOutputComplexType(evmType.components, { ...options, useStructs: true })
     case 'unknown':
       return 'any'
   }
 }
 
-export function codegenTupleType(tuple: TupleType, generator: (evmType: EvmType) => string) {
-  return '[' + tuple.components.map((component) => generator(component.type)).join(', ') + ']'
+export function codegenArrayOrTupleType(item: string, length?: number) {
+  if (length !== undefined && length < 6) {
+    return `[${Array(length).fill(item).join(', ')}]`
+  } else {
+    return `${item}[]`
+  }
+}
+
+export function codegenObjectTypeLiteral(tuple: TupleType, generator: (evmType: EvmType) => string) {
+  return '{' + tuple.components.map((component) => `${component.name}: ${generator(component.type)}`).join(', ') + '}'
+}
+
+/**
+ * Always return an array type; if there are named outputs, merge them to that type
+ * this generates slightly better typings fixing: https://github.com/ethereum-ts/TypeChain/issues/232
+ **/
+export function codegenOutputComplexType(components: AbiOutputParameter[], options: GenerateTypeOptions) {
+  const existingOutputComponents = compact([
+    codegenOutputComplexTypeAsArray(components, options),
+    codegenOutputComplexTypesAsObject(components, options),
+  ])
+  return existingOutputComponents.join(' & ')
+}
+
+export function codegenInputComplexType(components: AbiParameter[], options: GenerateTypeOptions) {
+  const existingOutputComponents = compact([
+    codegenInputComplexTypeAsArray(components, options),
+    codegenInputComplexTypesAsObject(components, options),
+  ])
+  return existingOutputComponents.join(' | ')
+}
+export function codegenOutputComplexTypeAsArray(
+  components: AbiOutputParameter[],
+  options: GenerateTypeOptions,
+): string {
+  return `[${components.map((t) => codegenOutputType(options, t.type)).join(', ')}]`
+}
+
+export function codegenOutputComplexTypesAsObject(
+  components: AbiOutputParameter[],
+  options: GenerateTypeOptions,
+): string | undefined {
+  let namedElementsCode
+  const namedElements = components.filter((e) => !!e.name)
+  if (namedElements.length > 0) {
+    namedElementsCode =
+      '{' + namedElements.map((t) => `${t.name}: ${codegenOutputType(options, t.type)}`).join(', ') + ' }'
+
+  }
+
+  return namedElementsCode
+}
+
+export function codegenInputComplexTypeAsArray(components: AbiParameter[], options: GenerateTypeOptions): string {
+  return `[${components.map((t) => codegenInputType(options, t.type)).join(', ')}]`
+}
+
+export function codegenInputComplexTypesAsObject(
+  components: AbiParameter[],
+  options: GenerateTypeOptions,
+): string | undefined {
+  let namedElementsCode
+  const namedElements = components.filter((e) => !!e.name)
+  if (namedElements.length > 0) {
+    namedElementsCode =
+      '{' + namedElements.map((t) => `${t.name}: ${codegenInputType(options, t.type)}`).join(', ') + ' }'
+  }
+
+  return namedElementsCode
 }

--- a/packages/target-web3-v1/src/common.ts
+++ b/packages/target-web3-v1/src/common.ts
@@ -1,0 +1,2 @@
+export const STRUCT_INPUT_POSTFIX = 'Struct'
+export const STRUCT_OUTPUT_POSTFIX = 'StructOutput'

--- a/packages/target-web3-v1/src/index.ts
+++ b/packages/target-web3-v1/src/index.ts
@@ -47,7 +47,7 @@ export default class Web3V1 extends TypeChainTarget {
 
     return {
       path: join(this.outDirAbs, ...contract.path, `${contract.name}.ts`),
-      contents: codegen(contract),
+      contents: codegen(contract, this.cfg.flags),
     }
   }
 


### PR DESCRIPTION
This PR adds support for struct parsing to @typechain/web3-v1, similarly to @typechain/ethers-v5.

Target from this PR is on [NPM ](https://www.npmjs.com/package/typechain-target-web3-v1-3mihai3) if you want to try it out