### PR TITLE
[web3.js] support BigNumber.js

### DIFF
--- a/packages/target-web3-v1-test/package.json
+++ b/packages/target-web3-v1-test/package.json
@@ -21,6 +21,7 @@
     "web3": "^1.6.0",
     "web3-eth-contract": "^1.6.0",
     "web3-core": "^1",
-    "@types/bn.js": "^4.11.6"
+    "@types/bn.js": "^4.11.6",
+    "bignumber.js": "^9"
   }
 }

--- a/packages/target-web3-v1-test/test/DataTypesInput.test.ts
+++ b/packages/target-web3-v1-test/test/DataTypesInput.test.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import BN from 'bn.js'
 import { q18, typedAssert } from 'test-utils'
 
@@ -7,26 +8,28 @@ import { createNewBlockchain } from './common'
 describe('DataTypesInput', () => {
   const chain = createNewBlockchain<DataTypesInput>('DataTypesInput')
 
-  const bn = (s: string) => new BN(s)
-
   it('works', async () => {
     const { contract, web3 } = chain
 
     typedAssert(await contract.methods.input_uint8('42').call(), '42')
     typedAssert(await contract.methods.input_uint8(42).call(), '42')
-    typedAssert(await contract.methods.input_uint8(bn('42')).call(), '42')
+    typedAssert(await contract.methods.input_uint8(new BN('42')).call(), '42')
+    typedAssert(await contract.methods.input_uint8(BigNumber('42')).call(), '42')
 
     typedAssert(await contract.methods.input_uint256(q18(1)).call(), q18(1))
     typedAssert(await contract.methods.input_uint256(1).call(), '1')
-    typedAssert(await contract.methods.input_uint256(bn(q18(1))).call(), q18(1))
+    typedAssert(await contract.methods.input_uint256(new BN(q18(1))).call(), q18(1))
+    typedAssert(await contract.methods.input_uint256(BigNumber(q18(1))).call(), q18(1))
 
     typedAssert(await contract.methods.input_int8('42').call(), '42')
     typedAssert(await contract.methods.input_int8(42).call(), '42')
-    typedAssert(await contract.methods.input_int8(bn('42')).call(), '42')
+    typedAssert(await contract.methods.input_int8(new BN('42')).call(), '42')
+    typedAssert(await contract.methods.input_int8(BigNumber('42')).call(), '42')
 
     typedAssert(await contract.methods.input_int256(q18(1)).call(), q18(1))
     typedAssert(await contract.methods.input_int256(1).call(), '1')
-    typedAssert(await contract.methods.input_int256(bn(q18(1))).call(), q18(1))
+    typedAssert(await contract.methods.input_int256(new BN(q18(1))).call(), q18(1))
+    typedAssert(await contract.methods.input_int256(BigNumber(q18(1))).call(), q18(1))
 
     typedAssert(await contract.methods.input_bool(true).call(), true)
 
@@ -47,23 +50,24 @@ describe('DataTypesInput', () => {
     typedAssert(await contract.methods.input_stat_array([1, 2, 3]).call(), ['1', '2', '3'])
 
     // TODO this fails due to an issue in web3 abi coder handling of inner BN (see https://github.com/ChainSafe/web3.js/issues/3920)
-    // typedAssert(
-    //   await contract.methods.input_stat_array([bn('1'), bn('2'), bn('3')]).call(),
-    //   ['1', '2', '3'],
-    // )
+    // typedAssert(await contract.methods.input_stat_array([new BN('1'), new BN('2'), new BN('3')]).call(),['1', '2', '3'],)
+    // typedAssert(await contract.methods.input_stat_array([BigNumber('1'), BigNumber('2'), BigNumber('3')]).call(),['1', '2', '3'],)
 
     typedAssert(await contract.methods.input_tuple('1', '2').call(), { 0: '1', 1: '2' })
     typedAssert(await contract.methods.input_tuple(1, 2).call(), { 0: '1', 1: '2' })
-    typedAssert(await contract.methods.input_tuple(bn('1'), bn('2')).call(), { 0: '1', 1: '2' })
+    typedAssert(await contract.methods.input_tuple(new BN('1'), new BN('2')).call(), { 0: '1', 1: '2' })
+    typedAssert(await contract.methods.input_tuple(BigNumber('1'), BigNumber('2')).call(), { 0: '1', 1: '2' })
 
     typedAssert(await contract.methods.input_struct(['1', '2']).call(), ['1', '2'])
     typedAssert(await contract.methods.input_struct([1, 2]).call(), ['1', '2'])
 
     // TODO this fails due to an issue in web3 abi coder handling of inner BN (see https://github.com/ChainSafe/web3.js/issues/3920)
-    // typedAssert(await contract.methods.input_struct([bn('1'), bn('2')]).call(), ['1', '2'])
+    // typedAssert(await contract.methods.input_struct([new BN('1'), new BN('2')]).call(), ['1', '2'])
+    // typedAssert(await contract.methods.input_struct([BigNumber('1'), BigNumber('2')]).call(), ['1', '2'])
 
     typedAssert(await contract.methods.input_enum('1').call(), '1')
     typedAssert(await contract.methods.input_enum(1).call(), '1')
-    typedAssert(await contract.methods.input_enum(bn('1')).call(), '1')
+    typedAssert(await contract.methods.input_enum(new BN('1')).call(), '1')
+    typedAssert(await contract.methods.input_enum(BigNumber('1')).call(), '1')
   })
 })

--- a/packages/target-web3-v1-test/test/Events.test.ts
+++ b/packages/target-web3-v1-test/test/Events.test.ts
@@ -1,4 +1,5 @@
-import BigNumber from 'bn.js'
+import BigNumber from 'bignumber.js'
+import BN from 'bn.js'
 import { asyncWithDoneCase, typedAssert } from 'test-utils'
 
 import type { Events } from '../types/v0.6.4/Events'
@@ -104,6 +105,14 @@ describe('Events', () => {
   describe('EIP1559 overrides', () => {
     it('works', async () => {
       const { accounts, contract } = chain
+
+      await contract.methods.emit_event1().send({
+        from: accounts[0],
+        gas: GAS_LIMIT_STANDARD,
+        maxFeePerGas: new BN(10 ** 9),
+        maxPriorityFeePerGas: new BN(10 ** 9),
+      })
+      // doesn't throw error
 
       await contract.methods.emit_event1().send({
         from: accounts[0],

--- a/packages/target-web3-v1-test/types/types.ts
+++ b/packages/target-web3-v1-test/types/types.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { EventEmitter } from "events";
 import type { EventLog, PromiEvent, TransactionReceipt } from "web3-core/types";
 import type { Contract } from "web3-eth-contract";
@@ -9,7 +10,7 @@ import type { Contract } from "web3-eth-contract";
 export interface EstimateGasOptions {
   from?: string;
   gas?: number;
-  value?: number | string | BN;
+  value?: number | string | BN | BigNumber;
 }
 
 export interface EventOptions {
@@ -32,19 +33,19 @@ export interface ContractEventEmitter<T> extends EventEmitter {
 }
 
 export interface NonPayableTx {
-  nonce?: string | number | BN;
-  chainId?: string | number | BN;
+  nonce?: string | number | BN | BigNumber;
+  chainId?: string | number | BN | BigNumber;
   from?: string;
   to?: string;
   data?: string;
-  gas?: string | number | BN;
-  maxPriorityFeePerGas?: string | number | BN;
-  maxFeePerGas?: string | number | BN;
-  gasPrice?: string | number | BN;
+  gas?: string | number | BN | BigNumber;
+  maxPriorityFeePerGas?: string | number | BN | BigNumber;
+  maxFeePerGas?: string | number | BN | BigNumber;
+  gasPrice?: string | number | BN | BigNumber;
 }
 
 export interface PayableTx extends NonPayableTx {
-  value?: string | number | BN;
+  value?: string | number | BN | BigNumber;
 }
 
 export interface NonPayableTransactionObject<T> {
@@ -69,5 +70,6 @@ export type BlockType =
   | "genesis"
   | "earliest"
   | number
-  | BN;
+  | BN
+  | BigNumber;
 export type BaseContract = Omit<Contract, "clone" | "once">;

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -40,110 +41,140 @@ export interface DataTypesInput extends BaseContract {
     ): NonPayableTransactionObject<string>;
 
     input_enum(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     input_fixedarray_array_fixedarray(
-      input1: (number | string | BN)[][][]
+      input1: (number | string | BN | BigNumber)[][][]
     ): NonPayableTransactionObject<string[][][]>;
 
     input_int256(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     input_int8(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     input_multiple_structs_with_same_name(
-      info1: [number | string | BN, number | string | BN]
+      info1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ]
     ): NonPayableTransactionObject<[string, string]>;
 
     input_stat_array(
-      input1: (number | string | BN)[]
+      input1: (number | string | BN | BigNumber)[]
     ): NonPayableTransactionObject<string[]>;
 
     input_string(input1: string): NonPayableTransactionObject<string>;
 
     input_struct(
-      input1: [number | string | BN, number | string | BN]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ]
     ): NonPayableTransactionObject<[string, string]>;
 
     input_struct2(
       input1: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
+        number | string | BN | BigNumber,
+        [number | string | BN | BigNumber, number | string | BN | BigNumber]
       ]
     ): NonPayableTransactionObject<[string, [string, string]]>;
 
     input_struct2_array(
       input1: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
+        number | string | BN | BigNumber,
+        [number | string | BN | BigNumber, number | string | BN | BigNumber]
       ][]
     ): NonPayableTransactionObject<[string, [string, string]][]>;
 
     input_struct2_tuple(
       input: [
-        number | string | BN,
-        [number | string | BN, number | string | BN]
+        number | string | BN | BigNumber,
+        [number | string | BN | BigNumber, number | string | BN | BigNumber]
       ][]
     ): NonPayableTransactionObject<[string, [string, string]][]>;
 
     input_struct3_array(
-      input1: [(number | string | BN)[]][]
+      input1: [(number | string | BN | BigNumber)[]][]
     ): NonPayableTransactionObject<[string[]][]>;
 
     input_struct_array(
-      input1: [number | string | BN, number | string | BN][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][]
     ): NonPayableTransactionObject<[string, string][]>;
 
     input_struct_array_array(
-      input1: [number | string | BN, number | string | BN][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][]
     ): NonPayableTransactionObject<[string, string][][]>;
 
     input_struct_array_array_array(
-      input1: [number | string | BN, number | string | BN][][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][][]
     ): NonPayableTransactionObject<[string, string][][][]>;
 
     input_struct_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][]
     ): NonPayableTransactionObject<[string, string][][]>;
 
     input_struct_fixedarray_array(
-      input1: [number | string | BN, number | string | BN][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][]
     ): NonPayableTransactionObject<[string, string][][]>;
 
     input_struct_fixedarray_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][][]
     ): NonPayableTransactionObject<[string, string][][][]>;
 
     input_struct_fixedarray_array_fixedarray_array_fixedarray(
-      input1: [number | string | BN, number | string | BN][][][][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][][][][]
     ): NonPayableTransactionObject<[string, string][][][][][]>;
 
     input_struct_fixedarray_fixedarray(
-      input1: [number | string | BN, number | string | BN][][]
+      input1: [
+        number | string | BN | BigNumber,
+        number | string | BN | BigNumber
+      ][][]
     ): NonPayableTransactionObject<[string, string][][]>;
 
     input_tuple(
-      input1: number | string | BN,
-      input2: number | string | BN
+      input1: number | string | BN | BigNumber,
+      input2: number | string | BN | BigNumber
     ): NonPayableTransactionObject<{
       0: string;
       1: string;
     }>;
 
     input_uint256(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     input_uint8(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     input_uint_array(
-      input1: (number | string | BN)[]
+      input1: (number | string | BN | BigNumber)[]
     ): NonPayableTransactionObject<string[]>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesPure.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesView.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Events.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Events.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/A.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/A.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/B.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Issue428_Reproduction/B.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Library/Lib.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Library/Lib.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -29,7 +30,9 @@ export interface Lib extends BaseContract {
   ): Lib;
   clone(): Lib;
   methods: {
-    other(b: number | string | BN): NonPayableTransactionObject<string>;
+    other(
+      b: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
   };
   events: {
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;

--- a/packages/target-web3-v1-test/types/v0.6.4/LibraryConsumer.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/LibraryConsumer.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -29,7 +30,9 @@ export interface LibraryConsumer extends BaseContract {
   ): LibraryConsumer;
   clone(): LibraryConsumer;
   methods: {
-    someOther(b: number | string | BN): NonPayableTransactionObject<string>;
+    someOther(
+      b: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
   };
   events: {
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;

--- a/packages/target-web3-v1-test/types/v0.6.4/Name-Mangling/NAME12mangling.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Name-Mangling/NAME12mangling.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Overloads.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Overloads.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -30,12 +31,12 @@ export interface Overloads extends BaseContract {
   clone(): Overloads;
   methods: {
     "overload1(int256)"(
-      input1: number | string | BN
+      input1: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     "overload1(uint256,uint256)"(
-      input1: number | string | BN,
-      input2: number | string | BN
+      input1: number | string | BN | BigNumber,
+      input2: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.6.4/Payable/Payable.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Payable/Payable.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.6.4/Payable/PayableFactory.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Payable/PayableFactory.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.8.9/ISimpleToken.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/ISimpleToken.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -31,7 +32,7 @@ export interface ISimpleToken extends BaseContract {
   methods: {
     transfer(
       from: string,
-      value: number | string | BN
+      value: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Issue552_Reproduction.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -30,14 +31,16 @@ export interface Issue552_Reproduction extends BaseContract {
   clone(): Issue552_Reproduction;
   methods: {
     bars(
-      arg0: number | string | BN
+      arg0: number | string | BN | BigNumber
     ): NonPayableTransactionObject<[[string, string][], string]>;
 
-    input(values: (number | string | BN)[]): NonPayableTransactionObject<void>;
+    input(
+      values: (number | string | BN | BigNumber)[]
+    ): NonPayableTransactionObject<void>;
 
     makeObservation(
-      barId: number | string | BN,
-      newVal: number | string | BN
+      barId: number | string | BN | BigNumber,
+      newVal: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/Withdrawable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/KingOfTheHill/Withdrawable.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -56,13 +57,13 @@ export interface ERC721 extends BaseContract {
   methods: {
     approve(
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     balanceOf(owner: string): NonPayableTransactionObject<string>;
 
     getApproved(
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     isApprovedForAll(
@@ -70,18 +71,20 @@ export interface ERC721 extends BaseContract {
       operator: string
     ): NonPayableTransactionObject<boolean>;
 
-    ownerOf(tokenId: number | string | BN): NonPayableTransactionObject<string>;
+    ownerOf(
+      tokenId: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     "safeTransferFrom(address,address,uint256)"(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     "safeTransferFrom(address,address,uint256,bytes)"(
       from: string,
       to: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       _data: string | number[]
     ): NonPayableTransactionObject<void>;
 
@@ -93,7 +96,7 @@ export interface ERC721 extends BaseContract {
     transferFrom(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721Enumerable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/ERC721Enumerable.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -56,13 +57,13 @@ export interface ERC721Enumerable extends BaseContract {
   methods: {
     approve(
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     balanceOf(owner: string): NonPayableTransactionObject<string>;
 
     getApproved(
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     isApprovedForAll(
@@ -70,18 +71,20 @@ export interface ERC721Enumerable extends BaseContract {
       operator: string
     ): NonPayableTransactionObject<boolean>;
 
-    ownerOf(tokenId: number | string | BN): NonPayableTransactionObject<string>;
+    ownerOf(
+      tokenId: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     "safeTransferFrom(address,address,uint256)"(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     "safeTransferFrom(address,address,uint256,bytes)"(
       from: string,
       to: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       _data: string | number[]
     ): NonPayableTransactionObject<void>;
 
@@ -91,12 +94,12 @@ export interface ERC721Enumerable extends BaseContract {
     ): NonPayableTransactionObject<void>;
 
     tokenByIndex(
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     tokenOfOwnerByIndex(
       owner: string,
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     totalSupply(): NonPayableTransactionObject<string>;
@@ -104,7 +107,7 @@ export interface ERC721Enumerable extends BaseContract {
     transferFrom(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -56,13 +57,13 @@ export interface IERC721 extends BaseContract {
   methods: {
     approve(
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     balanceOf(owner: string): NonPayableTransactionObject<string>;
 
     getApproved(
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     isApprovedForAll(
@@ -70,18 +71,20 @@ export interface IERC721 extends BaseContract {
       operator: string
     ): NonPayableTransactionObject<boolean>;
 
-    ownerOf(tokenId: number | string | BN): NonPayableTransactionObject<string>;
+    ownerOf(
+      tokenId: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     "safeTransferFrom(address,address,uint256)"(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     "safeTransferFrom(address,address,uint256,bytes)"(
       from: string,
       to: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       data: string | number[]
     ): NonPayableTransactionObject<void>;
 
@@ -93,7 +96,7 @@ export interface IERC721 extends BaseContract {
     transferFrom(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Enumerable.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Enumerable.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -56,13 +57,13 @@ export interface IERC721Enumerable extends BaseContract {
   methods: {
     approve(
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     balanceOf(owner: string): NonPayableTransactionObject<string>;
 
     getApproved(
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     isApprovedForAll(
@@ -70,18 +71,20 @@ export interface IERC721Enumerable extends BaseContract {
       operator: string
     ): NonPayableTransactionObject<boolean>;
 
-    ownerOf(tokenId: number | string | BN): NonPayableTransactionObject<string>;
+    ownerOf(
+      tokenId: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     "safeTransferFrom(address,address,uint256)"(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     "safeTransferFrom(address,address,uint256,bytes)"(
       from: string,
       to: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       data: string | number[]
     ): NonPayableTransactionObject<void>;
 
@@ -91,12 +94,12 @@ export interface IERC721Enumerable extends BaseContract {
     ): NonPayableTransactionObject<void>;
 
     tokenByIndex(
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     tokenOfOwnerByIndex(
       owner: string,
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     totalSupply(): NonPayableTransactionObject<string>;
@@ -104,7 +107,7 @@ export interface IERC721Enumerable extends BaseContract {
     transferFrom(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Receiver.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/IERC721Receiver.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -32,7 +33,7 @@ export interface IERC721Receiver extends BaseContract {
     onERC721Received(
       operator: string,
       from: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       data: string | number[]
     ): NonPayableTransactionObject<string>;
   };

--- a/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/Rarity/Rarity.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -71,26 +72,30 @@ export interface Rarity extends BaseContract {
   clone(): Rarity;
   methods: {
     adventure(
-      _summoner: number | string | BN
+      _summoner: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     adventurers_log(
-      arg0: number | string | BN
+      arg0: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     approve(
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     balanceOf(owner: string): NonPayableTransactionObject<string>;
 
-    class(arg0: number | string | BN): NonPayableTransactionObject<string>;
+    class(
+      arg0: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
-    classes(id: number | string | BN): NonPayableTransactionObject<string>;
+    classes(
+      id: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     getApproved(
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     isApprovedForAll(
@@ -98,26 +103,30 @@ export interface Rarity extends BaseContract {
       operator: string
     ): NonPayableTransactionObject<boolean>;
 
-    level(arg0: number | string | BN): NonPayableTransactionObject<string>;
+    level(
+      arg0: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     level_up(
-      _summoner: number | string | BN
+      _summoner: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     next_summoner(): NonPayableTransactionObject<string>;
 
-    ownerOf(tokenId: number | string | BN): NonPayableTransactionObject<string>;
+    ownerOf(
+      tokenId: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     "safeTransferFrom(address,address,uint256)"(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
     "safeTransferFrom(address,address,uint256,bytes)"(
       from: string,
       to: string,
-      tokenId: number | string | BN,
+      tokenId: number | string | BN | BigNumber,
       _data: string | number[]
     ): NonPayableTransactionObject<void>;
 
@@ -127,13 +136,17 @@ export interface Rarity extends BaseContract {
     ): NonPayableTransactionObject<void>;
 
     spend_xp(
-      _summoner: number | string | BN,
-      _xp: number | string | BN
+      _summoner: number | string | BN | BigNumber,
+      _xp: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
-    summon(_class: number | string | BN): NonPayableTransactionObject<void>;
+    summon(
+      _class: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<void>;
 
-    summoner(_summoner: number | string | BN): NonPayableTransactionObject<{
+    summoner(
+      _summoner: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<{
       _xp: string;
       _log: string;
       _class: string;
@@ -145,16 +158,16 @@ export interface Rarity extends BaseContract {
     }>;
 
     tokenByIndex(
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     tokenOfOwnerByIndex(
       owner: string,
-      index: number | string | BN
+      index: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     tokenURI(
-      _summoner: number | string | BN
+      _summoner: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
 
     totalSupply(): NonPayableTransactionObject<string>;
@@ -162,13 +175,15 @@ export interface Rarity extends BaseContract {
     transferFrom(
       from: string,
       to: string,
-      tokenId: number | string | BN
+      tokenId: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
 
-    xp(arg0: number | string | BN): NonPayableTransactionObject<string>;
+    xp(
+      arg0: number | string | BN | BigNumber
+    ): NonPayableTransactionObject<string>;
 
     xp_required(
-      curent_level: number | string | BN
+      curent_level: number | string | BN | BigNumber
     ): NonPayableTransactionObject<string>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/SimpleToken.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/SimpleToken.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";
@@ -31,7 +32,7 @@ export interface SimpleToken extends BaseContract {
   methods: {
     transfer(
       from: string,
-      value: number | string | BN
+      value: number | string | BN | BigNumber
     ): NonPayableTransactionObject<void>;
   };
   events: {

--- a/packages/target-web3-v1-test/types/v0.8.9/nested/a/NestedLibrary.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/nested/a/NestedLibrary.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1-test/types/v0.8.9/nested/b/NestedLibrary.ts
+++ b/packages/target-web3-v1-test/types/v0.8.9/nested/b/NestedLibrary.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type BN from "bn.js";
+import type BigNumber from "bignumber.js";
 import type { ContractOptions } from "web3-eth-contract";
 import type { EventLog } from "web3-core";
 import type { EventEmitter } from "events";

--- a/packages/target-web3-v1/package.json
+++ b/packages/target-web3-v1/package.json
@@ -34,7 +34,8 @@
     "typechain": "workspace:^8.1.0",
     "web3": "^1",
     "web3-core": "^1",
-    "web3-eth-contract": "^1"
+    "web3-eth-contract": "^1",
+    "bignumber.js": "*"
   },
   "devDependencies": {
     "typechain": "workspace:^8.1.0",
@@ -43,7 +44,8 @@
     "web3": "^1",
     "web3-core": "^1",
     "web3-eth-contract": "^1",
-    "@types/bn.js": "^4.11.6"
+    "@types/bn.js": "^4.11.6",
+    "bignumber.js": "^9"
   },
   "dependencies": {
     "lodash": "^4.17.15",

--- a/packages/target-web3-v1/src/codegen/index.ts
+++ b/packages/target-web3-v1/src/codegen/index.ts
@@ -8,6 +8,7 @@ export function codegen(contract: Contract) {
 
   const template = `
   import type BN from "bn.js";
+  import type BigNumber from "bignumber.js";
   import type { ContractOptions } from "web3-eth-contract";
   import type { EventLog } from "web3-core";
   import type { EventEmitter } from "events";

--- a/packages/target-web3-v1/src/codegen/types.ts
+++ b/packages/target-web3-v1/src/codegen/types.ts
@@ -24,7 +24,7 @@ export function codegenInputType(evmType: EvmType): string {
   switch (evmType.type) {
     case 'integer':
     case 'uinteger':
-      return 'number | string | BN'
+      return 'number | string | BN | BigNumber'
     case 'address':
       return 'string'
     case 'bytes':

--- a/packages/target-web3-v1/static/types.ts
+++ b/packages/target-web3-v1/static/types.ts
@@ -1,4 +1,5 @@
 import type BN from 'bn.js'
+import type BigNumber from 'bignumber.js'
 import type { EventEmitter } from 'events'
 import type { EventLog, PromiEvent, TransactionReceipt } from 'web3-core/types'
 import type { Contract } from 'web3-eth-contract'
@@ -6,7 +7,7 @@ import type { Contract } from 'web3-eth-contract'
 export interface EstimateGasOptions {
   from?: string
   gas?: number
-  value?: number | string | BN
+  value?: number | string | BN | BigNumber
 }
 
 export interface EventOptions {
@@ -26,19 +27,19 @@ export interface ContractEventEmitter<T> extends EventEmitter {
 }
 
 export interface NonPayableTx {
-  nonce?: string | number | BN
-  chainId?: string | number | BN
+  nonce?: string | number | BN | BigNumber
+  chainId?: string | number | BN | BigNumber
   from?: string
   to?: string
   data?: string
-  gas?: string | number | BN
-  maxPriorityFeePerGas?: string | number | BN
-  maxFeePerGas?: string | number | BN
-  gasPrice?: string | number | BN
+  gas?: string | number | BN | BigNumber
+  maxPriorityFeePerGas?: string | number | BN | BigNumber
+  maxFeePerGas?: string | number | BN | BigNumber
+  gasPrice?: string | number | BN | BigNumber
 }
 
 export interface PayableTx extends NonPayableTx {
-  value?: string | number | BN
+  value?: string | number | BN | BigNumber
 }
 
 export interface NonPayableTransactionObject<T> {
@@ -57,5 +58,5 @@ export interface PayableTransactionObject<T> {
   encodeABI(): string
 }
 
-export type BlockType = 'latest' | 'pending' | 'genesis' | 'earliest' | number | BN
+export type BlockType = 'latest' | 'pending' | 'genesis' | 'earliest' | number | BN | BigNumber
 export type BaseContract = Omit<Contract, 'clone' | 'once'>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,7 @@ importers:
     specifiers:
       '@types/bn.js': ^4.11.6
       '@types/lodash': ^4.14.139
+      bignumber.js: ^9.1.0
       lodash: ^4.17.15
       test-utils: 1.0.0
       ts-essentials: ^7.0.1
@@ -437,6 +438,7 @@ importers:
     devDependencies:
       '@types/bn.js': 4.11.6
       '@types/lodash': 4.14.179
+      bignumber.js: 9.1.0
       test-utils: link:../test-utils
       typechain: link:../typechain
       web3: 1.7.1
@@ -446,6 +448,7 @@ importers:
   packages/target-web3-v1-test:
     specifiers:
       '@types/bn.js': ^4.11.6
+      bignumber.js: ^9.1.0
       ganache: ^7.0.3
       test-utils: 1.0.0
       typechain: workspace:^8.1.0
@@ -454,6 +457,7 @@ importers:
       web3-eth-contract: ^1.6.0
     devDependencies:
       '@types/bn.js': 4.11.6
+      bignumber.js: 9.1.0
       ganache: 7.0.3
       test-utils: link:../test-utils
       typechain: link:../typechain
@@ -889,7 +893,7 @@ packages:
     dependencies:
       '@resolver-engine/imports': 0.3.3
       '@resolver-engine/imports-fs': 0.3.3
-      '@typechain/ethers-v5': 2.0.0_typechain@3.0.0
+      '@typechain/ethers-v5': 2.0.0_g7uto4b3myu3f235xnumgfxjwq
       '@types/mkdirp': 0.5.2
       '@types/node-fetch': 2.6.1
       ethers: 5.6.0
@@ -1813,7 +1817,7 @@ packages:
       '@ledgerhq/hw-transport': 6.27.1
       '@ledgerhq/logs': 6.10.0
       axios: 0.26.1
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
     transitivePeerDependencies:
       - debug
 
@@ -2876,7 +2880,7 @@ packages:
       '@nodefactory/filsnap-adapter': 0.2.2
       '@nodefactory/filsnap-types': 0.2.2
       '@zondax/filecoin-signing-tools': github.com/Digital-MOB-Filecoin/filecoin-signing-tools-js/8f8e92157cac2556d35cab866779e9a8ea8a4e25
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       bitcore-lib: 8.25.25
       bitcore-mnemonic: 8.25.25
       btoa-lite: 1.0.0
@@ -2913,16 +2917,14 @@ packages:
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
     dev: true
 
-  /@typechain/ethers-v5/2.0.0_typechain@3.0.0:
+  /@typechain/ethers-v5/2.0.0_g7uto4b3myu3f235xnumgfxjwq:
     resolution: {integrity: sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==}
     peerDependencies:
+      ethers: ^5.0.0
       typechain: ^3.0.0
     dependencies:
       ethers: 5.6.0
       typechain: 3.0.0_typescript@4.6.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     dev: true
 
   /@types/abstract-leveldown/7.2.0:
@@ -2945,7 +2947,7 @@ packages:
     resolution: {integrity: sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==}
     deprecated: This is a stub types definition for bignumber.js (https://github.com/MikeMcl/bignumber.js/). bignumber.js provides its own type definitions, so you don't need @types/bignumber.js installed!
     dependencies:
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
     dev: true
 
   /@types/bluebird/3.5.36:
@@ -4677,6 +4679,9 @@ packages:
   /bignumber.js/9.0.2:
     resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==}
 
+  /bignumber.js/9.1.0:
+    resolution: {integrity: sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==}
+
   /binary-extensions/2.1.0:
     resolution: {integrity: sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==}
     engines: {node: '>=8'}
@@ -4806,7 +4811,7 @@ packages:
     resolution: {integrity: sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==}
     engines: {node: '>=4'}
     dependencies:
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       buffer: 5.7.1
       commander: 2.20.3
       ieee754: 1.2.1
@@ -5112,7 +5117,7 @@ packages:
     resolution: {integrity: sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       nofilter: 1.0.4
 
   /chai-as-promised/7.1.1_chai@4.3.6:
@@ -8707,7 +8712,7 @@ packages:
     engines: {node: '>=10.3.0', npm: '>=3.0.0'}
     dependencies:
       any-signal: 2.1.2
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       cids: 1.1.9
       debug: 4.3.3
       form-data: 3.0.1
@@ -9516,7 +9521,7 @@ packages:
   /json-bigint/1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
     dependencies:
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
 
   /json-buffer/3.0.0:
     resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
@@ -14283,7 +14288,6 @@ packages:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /typewise-core/1.2.0:
     resolution: {integrity: sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU=}
@@ -14919,7 +14923,7 @@ packages:
     dependencies:
       '@types/bn.js': 4.11.6
       '@types/node': 12.19.14
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       web3-core-helpers: 1.2.11
       web3-core-method: 1.2.11
       web3-core-requestmanager: 1.2.11
@@ -14935,7 +14939,7 @@ packages:
     dependencies:
       '@types/bn.js': 4.11.6
       '@types/node': 12.19.14
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       web3-core-helpers: 1.3.6
       web3-core-method: 1.3.6
       web3-core-requestmanager: 1.3.6
@@ -14950,7 +14954,7 @@ packages:
     dependencies:
       '@types/bn.js': 4.11.6
       '@types/node': 12.19.14
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       web3-core-helpers: 1.5.3
       web3-core-method: 1.5.3
       web3-core-requestmanager: 1.5.3
@@ -14978,7 +14982,7 @@ packages:
     dependencies:
       '@types/bn.js': 4.11.6
       '@types/node': 12.19.14
-      bignumber.js: 9.0.2
+      bignumber.js: 9.1.0
       web3-core-helpers: 1.7.3
       web3-core-method: 1.7.3
       web3-core-requestmanager: 1.7.3


### PR DESCRIPTION
[BigNumber.js](https://github.com/MikeMcl/bignumber.js/) is a small and very popular library when developing for web3.
`web3.js` supports BigNumber as well as BN as input values to methods, events etc; so this PR adds support for the types generated by TypeChain to accept either.