### PR TITLE
Skip run if project has no ABIs

### DIFF
--- a/.changeset/fast-hornets-trade.md
+++ b/.changeset/fast-hornets-trade.md
@@ -1,0 +1,5 @@
+---
+'typechain': patch
+---
+
+Skip run if project has no ABIs

--- a/packages/typechain/src/typechain/runTypeChain.ts
+++ b/packages/typechain/src/typechain/runTypeChain.ts
@@ -22,6 +22,11 @@ export const DEFAULT_FLAGS: CodegenConfig = {
 
 export async function runTypeChain(publicConfig: PublicConfig): Promise<Result> {
   const allFiles = skipEmptyAbis(publicConfig.allFiles)
+  if (allFiles.length === 0) {
+    return {
+      filesGenerated: 0,
+    }
+  }
 
   // skip empty paths
   const config: Config = {


### PR DESCRIPTION
Skip typechain run if all ABIs in a project are empty (which can occur if the project has a single empty contract).

Fixes #717
Fixes #728