### PR TITLE
Add node16-modules flag to support Node16/NodeNext modules resolutions

### DIFF
--- a/packages/target-ethers-v5/src/codegen/index.ts
+++ b/packages/target-ethers-v5/src/codegen/index.ts
@@ -116,9 +116,10 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
     };
   }`
 
-  const commonPath = contract.path.length
-    ? `${new Array(contract.path.length).fill('..').join('/')}/common`
-    : './common'
+  const moduleSuffix = codegenConfig.node16Modules ? '.js' : ''
+  const commonPath =
+    (contract.path.length ? `${new Array(contract.path.length).fill('..').join('/')}/common` : './common') +
+    moduleSuffix
 
   const imports =
     createImportsForUsedIdentifiers(
@@ -153,6 +154,7 @@ export function codegenContractFactory(
   abi: any,
   bytecode?: BytecodeWithLinkReferences,
 ): string {
+  const moduleSuffix = codegenConfig.node16Modules ? '.js' : ''
   const constructorArgs =
     (contract.constructor[0] ? generateInputTypes(contract.constructor[0].inputs, { useStructs: true }) : '') +
     `overrides?: ${
@@ -166,11 +168,11 @@ export function codegenContractFactory(
   const constructorArgNames = constructorArgNamesWithoutOverrides
     ? `${constructorArgNamesWithoutOverrides}, overrides || {}`
     : 'overrides || {}'
-  if (!bytecode) return codegenAbstractContractFactory(contract, abi)
+  if (!bytecode) return codegenAbstractContractFactory(contract, abi, moduleSuffix)
 
   // tsc with noUnusedLocals would complain about unused imports
 
-  const { body, header } = codegenCommonContractFactory(contract, abi)
+  const { body, header } = codegenCommonContractFactory(contract, abi, moduleSuffix)
 
   const source = `
   ${header}
@@ -202,7 +204,7 @@ export function codegenContractFactory(
   ${generateLibraryAddressesInterface(contract, bytecode)}
   `
 
-  const commonPath = `${new Array(contract.path.length + 1).fill('..').join('/')}/common`
+  const commonPath = `${new Array(contract.path.length + 1).fill('..').join('/')}/common${moduleSuffix}`
 
   const imports =
     createImportsForUsedIdentifiers(
@@ -227,8 +229,8 @@ export function codegenContractFactory(
   return imports + source
 }
 
-export function codegenAbstractContractFactory(contract: Contract, abi: any): string {
-  const { body, header } = codegenCommonContractFactory(contract, abi)
+export function codegenAbstractContractFactory(contract: Contract, abi: any, moduleSuffix = ''): string {
+  const { body, header } = codegenCommonContractFactory(contract, abi, moduleSuffix)
   return `
   import { Contract, Signer, utils } from "ethers";
   import type { Provider } from "@ethersproject/providers";
@@ -240,7 +242,11 @@ export function codegenAbstractContractFactory(contract: Contract, abi: any): st
   `
 }
 
-function codegenCommonContractFactory(contract: Contract, abi: any): { header: string; body: string } {
+function codegenCommonContractFactory(
+  contract: Contract,
+  abi: any,
+  moduleSuffix = '',
+): { header: string; body: string } {
   const imports: Set<string> = new Set([contract.name, contract.name + 'Interface'])
 
   contract.constructor[0]?.inputs.forEach(({ type }) => {
@@ -250,9 +256,11 @@ function codegenCommonContractFactory(contract: Contract, abi: any): { header: s
     }
   })
 
-  const contractTypesImportPath = [...Array(contract.path.length + 1).fill('..'), ...contract.path, contract.name].join(
-    '/',
-  )
+  const contractTypesImportPath = [
+    ...Array(contract.path.length + 1).fill('..'),
+    ...contract.path,
+    contract.name + moduleSuffix,
+  ].join('/')
 
   const header = `
   import type { ${[...imports.values()].join(', ')} } from "${contractTypesImportPath}";

--- a/packages/typechain/src/cli/parseArgs.ts
+++ b/packages/typechain/src/cli/parseArgs.ts
@@ -11,6 +11,7 @@ export interface ParsedArgs {
     discriminateTypes: boolean
     alwaysGenerateOverloads: boolean
     tsNocheck: boolean
+    node16Modules: boolean
   }
 }
 
@@ -55,6 +56,12 @@ export function parseArgs(): ParsedArgs {
         description:
           'ethers-v5 target will add an artificial field `contractName` that helps discriminate between contracts',
       },
+      'node16-modules': {
+        type: Boolean,
+        defaultValue: false,
+        description:
+          'Append .js extension for relative module imports to support Node native ESM support.',
+      },
       help: { type: Boolean, defaultValue: false, alias: 'h', description: 'Prints this message.' },
     },
     {
@@ -88,6 +95,7 @@ export function parseArgs(): ParsedArgs {
       alwaysGenerateOverloads: rawOptions['always-generate-overloads'],
       discriminateTypes: rawOptions['discriminate-types'],
       tsNocheck: rawOptions['ts-nocheck'],
+      node16Modules: rawOptions['node16-modules'],
     },
   }
 }
@@ -101,5 +109,6 @@ interface CommandLineArgs {
   'always-generate-overloads': boolean
   'discriminate-types': boolean
   'ts-nocheck': boolean
+  'node16-modules': boolean
   help: boolean
 }

--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -11,7 +11,7 @@ import { FileDescription } from '../typechain/types'
  */
 export function createBarrelFiles(
   paths: string[],
-  { typeOnly, postfix = '' }: { typeOnly: boolean; postfix?: string },
+  { typeOnly, postfix = '', moduleSuffix = '' }: { typeOnly: boolean; postfix?: string; moduleSuffix?: string },
 ): FileDescription[] {
   const fileReexports: Record<string, string[] | undefined> = mapValues(
     groupBy(paths.map(posix.parse), (p) => p.dir),
@@ -55,7 +55,7 @@ export function createBarrelFiles(
 
         if (typeOnly)
           return [
-            `import type * as ${namespaceIdentifier} from './${p}';`,
+            `import type * as ${namespaceIdentifier} from './${p}}';`,
             `export type { ${namespaceIdentifier} };`,
           ].join('\n')
 
@@ -70,7 +70,7 @@ export function createBarrelFiles(
         const name = `${normalizeName(p)}${postfix}`
         // We can't always `export *` because of possible name conflicts.
         // @todo possibly a config option for user to decide?
-        return `${exportKeyword} { ${name} } from './${name}';`
+        return `${exportKeyword} { ${name} } from './${name}${moduleSuffix}';`
       })
       .join('\n')
 

--- a/packages/typechain/src/typechain/types.ts
+++ b/packages/typechain/src/typechain/types.ts
@@ -23,7 +23,9 @@ export interface CodegenConfig {
   alwaysGenerateOverloads: boolean
   discriminateTypes: boolean // ethers-v5 will add an artificial field `contractName` that helps discriminate between contracts
   tsNocheck?: boolean
+  node16Modules?: boolean
   environment: 'hardhat' | undefined
+
 }
 
 export type PublicConfig = MarkOptional<Config, 'flags' | 'inputDir'>


### PR DESCRIPTION
TypeScript's Node16/NodeNext module resolution brings uniform native ESM module support to Node/ESM environments as well as support for multiple entrypoints via package.json `exports`. However it explicitly requires relative imports to use file extensions for modules, usually '.js'.

This change introduces a `node16Modules` codegen config. Currently it just adds the module suffix `.js` to imports and exports where needed.

Without this it is impossible to use Typechain generated code with tsconfig moduleResolution: Node16 or NodeNext.

Signed-off-by: Silas Davis <silas.davis@monaxlabs.io>