### PR TITLE
fix(ethers-v6): TypedContractEvent should extend EventLog

### DIFF
--- a/packages/target-ethers-v6/static/common.ts
+++ b/packages/target-ethers-v6/static/common.ts
@@ -11,7 +11,7 @@ export interface TypedContractEvent<
   InputTuple extends Array<any> = any,
   OutputTuple extends Array<any> = any,
   OutputObject = any,
-> {
+> extends EventLog {
   (...args: Partial<InputTuple>): TypedDeferredTopicFilter<TypedContractEvent<InputTuple, OutputTuple, OutputObject>>
   name: string
   fragment: EventFragment


### PR DESCRIPTION
This is to align with v5:

```
import type { Event } from "ethers";

export interface TypedEvent<
  TArgsArray extends Array<any> = any,
  TArgsObject = any
> extends Event {
  args: TArgsArray & TArgsObject;
}
```

so that we can type the event log with it.