### PR TITLE
Remove obsolete peer dependency `@ethersproject/bytes@^5.0.0` from `target-ethers-v5`

### DIFF
--- a/.changeset/funny-cobras-invent.md
+++ b/.changeset/funny-cobras-invent.md
@@ -1,0 +1,5 @@
+---
+"@typechain/ethers-v5": patch
+---
+
+Remove obsolete peer dependency `@ethersproject/bytes@^5.0.0` from `target-ethers-v5`

--- a/packages/target-ethers-v5/package.json
+++ b/packages/target-ethers-v5/package.json
@@ -34,7 +34,6 @@
   },
   "peerDependencies": {
     "@ethersproject/abi": "^5.0.0",
-    "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/providers": "^5.0.0",
     "ethers": "^5.1.3",
     "typechain": "workspace:^8.1.1",


### PR DESCRIPTION
Fixes #822. No changeset added since it will not cause an immediate version bump.