### PR TITLE
[ethers-v5] Fix event and function signatures with tuples and array of tuples

### DIFF
--- a/.changeset/three-schools-peel.md
+++ b/.changeset/three-schools-peel.md
@@ -1,0 +1,6 @@
+---
+'@typechain/ethers-v5': minor
+'typechain': minor
+---
+
+fix tuples in event signatures and also arrays of tuples in functions

--- a/contracts/v0.6.4/DataTypesInput.sol
+++ b/contracts/v0.6.4/DataTypesInput.sol
@@ -101,6 +101,10 @@ contract DataTypesInput {
     info2.a = address(info1.a);
     info2.b = address(info1.b);
   }
+
+  event event_struct(Struct1 input);
+
+  event event_struct_2(uint256 input, Struct1 input2);
 }
 
 library StructsLib1 {

--- a/contracts/v0.6.4/Events.sol
+++ b/contracts/v0.6.4/Events.sol
@@ -45,5 +45,11 @@ contract Events {
     emit Event4(EventData(2, "test"));
   }
 
+  event Event5(EventData[2] data);
+
+  function emit_event5() public {
+    emit Event5([EventData(2, "test"), EventData(3, "test2")]);
+  }
+
   event NoArgsEvent();
 }

--- a/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
@@ -92,7 +92,8 @@ describe('DataTypesInput', () => {
   })
 
   it('generates correct function signature for tuples with fixed length', () => {
-    const fragment: FunctionFragment = chain.contract.interface.functions['input_struct2_tuple((uint256,(uint256,uint256))[3])']
+    const fragment: FunctionFragment =
+      chain.contract.interface.functions['input_struct2_tuple((uint256,(uint256,uint256))[3])']
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     expect(fragment !== undefined).toEqual(true)
   })

--- a/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
+++ b/packages/target-ethers-v5-test/test/DataTypesInput.test.ts
@@ -1,4 +1,4 @@
-import type { FunctionFragment } from '@ethersproject/abi'
+import type { EventFragment, FunctionFragment } from '@ethersproject/abi'
 import { expect } from 'earljs'
 import type { BigNumberish } from 'ethers'
 import { BigNumber, ethers } from 'ethers'
@@ -79,8 +79,32 @@ describe('DataTypesInput', () => {
     typedAssert(await chain.contract.input_enum(1), 1)
   })
 
-  it('generates correct signature for tuples', () => {
+  it('generates correct function signature for tuples', () => {
     const fragment: FunctionFragment = chain.contract.interface.functions['input_struct((uint256,uint256))']
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    expect(fragment !== undefined).toEqual(true)
+  })
+
+  it('generates correct function signature for tuples arrays', () => {
+    const fragment: FunctionFragment = chain.contract.interface.functions['input_struct3_array((uint256[])[])']
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    expect(fragment !== undefined).toEqual(true)
+  })
+
+  it('generates correct function signature for tuples with fixed length', () => {
+    const fragment: FunctionFragment = chain.contract.interface.functions['input_struct2_tuple((uint256,(uint256,uint256))[3])']
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    expect(fragment !== undefined).toEqual(true)
+  })
+
+  it('generate correct event signature for tuples', () => {
+    const fragment: EventFragment = chain.contract.interface.events['event_struct((uint256,uint256))']
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    expect(fragment !== undefined).toEqual(true)
+  })
+
+  it('generate correct event signature for mix of arguments and tuples', () => {
+    const fragment: EventFragment = chain.contract.interface.events['event_struct_2(uint256,(uint256,uint256))']
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     expect(fragment !== undefined).toEqual(true)
   })

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -33,7 +33,7 @@ describe('Events', () => {
 
     const filter = contract.filters.Event1(null, null)
     const results = await contract.queryFilter(filter)
-    
+
     typedAssert(results.length, 1)
     results.map((r) => {
       typedAssert(r.args.value1, BigNumber.from(1))
@@ -50,10 +50,10 @@ describe('Events', () => {
     const results = await contract.queryFilter(filter)
     typedAssert(results.length, 1)
     results.map((r) => {
-      typedAssert(r.args[0][0][0],  BigNumber.from(2))
-      typedAssert(r.args[0][0][1], "test")
+      typedAssert(r.args[0][0][0], BigNumber.from(2))
+      typedAssert(r.args[0][0][1], 'test')
       typedAssert(r.args[0][1][0], BigNumber.from(3))
-      typedAssert(r.args[0][1][1], "test2")
+      typedAssert(r.args[0][1][1], 'test2')
     })
   })
 

--- a/packages/target-ethers-v5-test/test/Events.test.ts
+++ b/packages/target-ethers-v5-test/test/Events.test.ts
@@ -33,11 +33,27 @@ describe('Events', () => {
 
     const filter = contract.filters.Event1(null, null)
     const results = await contract.queryFilter(filter)
+    
+    typedAssert(results.length, 1)
     results.map((r) => {
       typedAssert(r.args.value1, BigNumber.from(1))
       typedAssert(r.args.value2, BigNumber.from(2))
       typedAssert(r.args[0], BigNumber.from(1))
       typedAssert(r.args[1], BigNumber.from(2))
+    })
+  })
+
+  it('queryFilter with tuples and arrays', async () => {
+    await contract.emit_event5()
+
+    const filter = contract.filters.Event5(null)
+    const results = await contract.queryFilter(filter)
+    typedAssert(results.length, 1)
+    results.map((r) => {
+      typedAssert(r.args[0][0][0],  BigNumber.from(2))
+      typedAssert(r.args[0][0][1], "test")
+      typedAssert(r.args[0][1][0], BigNumber.from(3))
+      typedAssert(r.args[0][1][1], "test2")
     })
   })
 

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesInput__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/DataTypesInput__factory.ts
@@ -11,6 +11,62 @@ import type {
 
 const _abi = [
   {
+    anonymous: false,
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "uint256_0",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "uint256_1",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct DataTypesInput.Struct1",
+        name: "input",
+        type: "tuple",
+      },
+    ],
+    name: "event_struct",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "input",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "uint256_0",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "uint256_1",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct DataTypesInput.Struct1",
+        name: "input2",
+        type: "tuple",
+      },
+    ],
+    name: "event_struct_2",
+    type: "event",
+  },
+  {
     inputs: [
       {
         internalType: "address",

--- a/packages/target-ethers-v5-test/types/factories/v0.6.4/Events__factory.ts
+++ b/packages/target-ethers-v5-test/types/factories/v0.6.4/Events__factory.ts
@@ -111,6 +111,31 @@ const _abi = [
   },
   {
     anonymous: false,
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "index",
+            type: "uint256",
+          },
+          {
+            internalType: "string",
+            name: "name",
+            type: "string",
+          },
+        ],
+        indexed: false,
+        internalType: "struct Events.EventData[2]",
+        name: "data",
+        type: "tuple[2]",
+      },
+    ],
+    name: "Event5",
+    type: "event",
+  },
+  {
+    anonymous: false,
     inputs: [],
     name: "NoArgsEvent",
     type: "event",
@@ -172,6 +197,13 @@ const _abi = [
   {
     inputs: [],
     name: "emit_event4",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "emit_event5",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/packages/target-ethers-v5-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-ethers-v5-test/types/v0.6.4/DataTypesInput.ts
@@ -11,7 +11,11 @@ import type {
   Signer,
   utils,
 } from "ethers";
-import type { FunctionFragment, Result } from "@ethersproject/abi";
+import type {
+  FunctionFragment,
+  Result,
+  EventFragment,
+} from "@ethersproject/abi";
 import type { Listener, Provider } from "@ethersproject/providers";
 import type {
   TypedEventFilter,
@@ -19,21 +23,6 @@ import type {
   TypedListener,
   OnEvent,
 } from "../common";
-
-export declare namespace StructsLib1 {
-  export type InfoStruct = { a: BigNumberish; b: BigNumberish };
-
-  export type InfoStructOutput = [BigNumber, BigNumber] & {
-    a: BigNumber;
-    b: BigNumber;
-  };
-}
-
-export declare namespace StructsLib2 {
-  export type InfoStruct = { a: string; b: string };
-
-  export type InfoStructOutput = [string, string] & { a: string; b: string };
-}
 
 export declare namespace DataTypesInput {
   export type Struct1Struct = {
@@ -61,6 +50,21 @@ export declare namespace DataTypesInput {
   export type Struct3StructOutput = [BigNumber[]] & { input1: BigNumber[] };
 }
 
+export declare namespace StructsLib1 {
+  export type InfoStruct = { a: BigNumberish; b: BigNumberish };
+
+  export type InfoStructOutput = [BigNumber, BigNumber] & {
+    a: BigNumber;
+    b: BigNumber;
+  };
+}
+
+export declare namespace StructsLib2 {
+  export type InfoStruct = { a: string; b: string };
+
+  export type InfoStructOutput = [string, string] & { a: string; b: string };
+}
+
 export interface DataTypesInputInterface extends utils.Interface {
   functions: {
     "input_address(address)": FunctionFragment;
@@ -77,16 +81,16 @@ export interface DataTypesInputInterface extends utils.Interface {
     "input_struct((uint256,uint256))": FunctionFragment;
     "input_struct2((uint256,(uint256,uint256)))": FunctionFragment;
     "input_struct2_array((uint256,(uint256,uint256))[])": FunctionFragment;
-    "input_struct2_tuple(tuple[3])": FunctionFragment;
+    "input_struct2_tuple((uint256,(uint256,uint256))[3])": FunctionFragment;
     "input_struct3_array((uint256[])[])": FunctionFragment;
     "input_struct_array((uint256,uint256)[])": FunctionFragment;
-    "input_struct_array_array(tuple[][])": FunctionFragment;
-    "input_struct_array_array_array(tuple[][][])": FunctionFragment;
-    "input_struct_array_fixedarray(tuple[][2])": FunctionFragment;
-    "input_struct_fixedarray_array(tuple[2][])": FunctionFragment;
-    "input_struct_fixedarray_array_fixedarray(tuple[2][][3])": FunctionFragment;
-    "input_struct_fixedarray_array_fixedarray_array_fixedarray(tuple[2][][3][][4])": FunctionFragment;
-    "input_struct_fixedarray_fixedarray(tuple[2][3])": FunctionFragment;
+    "input_struct_array_array((uint256,uint256)[][])": FunctionFragment;
+    "input_struct_array_array_array((uint256,uint256)[][][])": FunctionFragment;
+    "input_struct_array_fixedarray((uint256,uint256)[][2])": FunctionFragment;
+    "input_struct_fixedarray_array((uint256,uint256)[2][])": FunctionFragment;
+    "input_struct_fixedarray_array_fixedarray((uint256,uint256)[2][][3])": FunctionFragment;
+    "input_struct_fixedarray_array_fixedarray_array_fixedarray((uint256,uint256)[2][][3][][4])": FunctionFragment;
+    "input_struct_fixedarray_fixedarray((uint256,uint256)[2][3])": FunctionFragment;
     "input_tuple(uint256,uint256)": FunctionFragment;
     "input_uint256(uint256)": FunctionFragment;
     "input_uint8(uint8)": FunctionFragment;
@@ -387,8 +391,35 @@ export interface DataTypesInputInterface extends utils.Interface {
     data: BytesLike
   ): Result;
 
-  events: {};
+  events: {
+    "event_struct((uint256,uint256))": EventFragment;
+    "event_struct_2(uint256,(uint256,uint256))": EventFragment;
+  };
+
+  getEvent(nameOrSignatureOrTopic: "event_struct"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "event_struct_2"): EventFragment;
 }
+
+export interface event_structEventObject {
+  input: DataTypesInput.Struct1StructOutput;
+}
+export type event_structEvent = TypedEvent<
+  [DataTypesInput.Struct1StructOutput],
+  event_structEventObject
+>;
+
+export type event_structEventFilter = TypedEventFilter<event_structEvent>;
+
+export interface event_struct_2EventObject {
+  input: BigNumber;
+  input2: DataTypesInput.Struct1StructOutput;
+}
+export type event_struct_2Event = TypedEvent<
+  [BigNumber, DataTypesInput.Struct1StructOutput],
+  event_struct_2EventObject
+>;
+
+export type event_struct_2EventFilter = TypedEventFilter<event_struct_2Event>;
 
 export interface DataTypesInput extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
@@ -1237,7 +1268,16 @@ export interface DataTypesInput extends BaseContract {
     ): Promise<BigNumber[]>;
   };
 
-  filters: {};
+  filters: {
+    "event_struct((uint256,uint256))"(input?: null): event_structEventFilter;
+    event_struct(input?: null): event_structEventFilter;
+
+    "event_struct_2(uint256,(uint256,uint256))"(
+      input?: null,
+      input2?: null
+    ): event_struct_2EventFilter;
+    event_struct_2(input?: null, input2?: null): event_struct_2EventFilter;
+  };
 
   estimateGas: {
     input_address(

--- a/packages/target-ethers-v5-test/types/v0.6.4/Events.ts
+++ b/packages/target-ethers-v5-test/types/v0.6.4/Events.ts
@@ -43,6 +43,7 @@ export interface EventsInterface extends utils.Interface {
     "emit_event3()": FunctionFragment;
     "emit_event3_overloaded()": FunctionFragment;
     "emit_event4()": FunctionFragment;
+    "emit_event5()": FunctionFragment;
   };
 
   getFunction(
@@ -53,6 +54,7 @@ export interface EventsInterface extends utils.Interface {
       | "emit_event3"
       | "emit_event3_overloaded"
       | "emit_event4"
+      | "emit_event5"
   ): FunctionFragment;
 
   encodeFunctionData(
@@ -79,6 +81,10 @@ export interface EventsInterface extends utils.Interface {
     functionFragment: "emit_event4",
     values?: undefined
   ): string;
+  encodeFunctionData(
+    functionFragment: "emit_event5",
+    values?: undefined
+  ): string;
 
   decodeFunctionResult(functionFragment: "emit_anon1", data: BytesLike): Result;
   decodeFunctionResult(
@@ -101,6 +107,10 @@ export interface EventsInterface extends utils.Interface {
     functionFragment: "emit_event4",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(
+    functionFragment: "emit_event5",
+    data: BytesLike
+  ): Result;
 
   events: {
     "AnonEvent1(uint256)": EventFragment;
@@ -108,7 +118,8 @@ export interface EventsInterface extends utils.Interface {
     "Event2(uint256)": EventFragment;
     "Event3(bool,uint256)": EventFragment;
     "Event3(uint256)": EventFragment;
-    "Event4(tuple)": EventFragment;
+    "Event4((uint256,string))": EventFragment;
+    "Event5((uint256,string)[2])": EventFragment;
     "NoArgsEvent()": EventFragment;
     "UpdateFrequencySet(address[],uint256[])": EventFragment;
   };
@@ -119,6 +130,7 @@ export interface EventsInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "Event3(bool,uint256)"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "Event3(uint256)"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "Event4"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "Event5"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "NoArgsEvent"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "UpdateFrequencySet"): EventFragment;
 }
@@ -176,6 +188,16 @@ export type Event4Event = TypedEvent<
 >;
 
 export type Event4EventFilter = TypedEventFilter<Event4Event>;
+
+export interface Event5EventObject {
+  data: [Events.EventDataStructOutput, Events.EventDataStructOutput];
+}
+export type Event5Event = TypedEvent<
+  [[Events.EventDataStructOutput, Events.EventDataStructOutput]],
+  Event5EventObject
+>;
+
+export type Event5EventFilter = TypedEventFilter<Event5Event>;
 
 export interface NoArgsEventEventObject {}
 export type NoArgsEventEvent = TypedEvent<[], NoArgsEventEventObject>;
@@ -244,6 +266,10 @@ export interface Events extends BaseContract {
     emit_event4(
       overrides?: Overrides & { from?: string }
     ): Promise<ContractTransaction>;
+
+    emit_event5(
+      overrides?: Overrides & { from?: string }
+    ): Promise<ContractTransaction>;
   };
 
   emit_anon1(
@@ -270,6 +296,10 @@ export interface Events extends BaseContract {
     overrides?: Overrides & { from?: string }
   ): Promise<ContractTransaction>;
 
+  emit_event5(
+    overrides?: Overrides & { from?: string }
+  ): Promise<ContractTransaction>;
+
   callStatic: {
     emit_anon1(overrides?: CallOverrides): Promise<void>;
 
@@ -282,6 +312,8 @@ export interface Events extends BaseContract {
     emit_event3_overloaded(overrides?: CallOverrides): Promise<void>;
 
     emit_event4(overrides?: CallOverrides): Promise<void>;
+
+    emit_event5(overrides?: CallOverrides): Promise<void>;
   };
 
   filters: {
@@ -303,8 +335,11 @@ export interface Events extends BaseContract {
     ): Event3_bool_uint256_EventFilter;
     "Event3(uint256)"(value1?: BigNumberish | null): Event3_uint256_EventFilter;
 
-    "Event4(tuple)"(data?: null): Event4EventFilter;
+    "Event4((uint256,string))"(data?: null): Event4EventFilter;
     Event4(data?: null): Event4EventFilter;
+
+    "Event5((uint256,string)[2])"(data?: null): Event5EventFilter;
+    Event5(data?: null): Event5EventFilter;
 
     "NoArgsEvent()"(): NoArgsEventEventFilter;
     NoArgsEvent(): NoArgsEventEventFilter;
@@ -330,6 +365,8 @@ export interface Events extends BaseContract {
     ): Promise<BigNumber>;
 
     emit_event4(overrides?: Overrides & { from?: string }): Promise<BigNumber>;
+
+    emit_event5(overrides?: Overrides & { from?: string }): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -354,6 +391,10 @@ export interface Events extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     emit_event4(
+      overrides?: Overrides & { from?: string }
+    ): Promise<PopulatedTransaction>;
+
+    emit_event5(
       overrides?: Overrides & { from?: string }
     ): Promise<PopulatedTransaction>;
   };

--- a/packages/target-ethers-v5-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
+++ b/packages/target-ethers-v5-test/types/v0.8.9/KingOfTheHill/KingOfTheHill.ts
@@ -59,7 +59,7 @@ export interface KingOfTheHillInterface extends utils.Interface {
   decodeFunctionResult(functionFragment: "withdraw", data: BytesLike): Result;
 
   events: {
-    "HighestBidIncreased(tuple)": EventFragment;
+    "HighestBidIncreased((address,uint256))": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "HighestBidIncreased"): EventFragment;
@@ -139,7 +139,9 @@ export interface KingOfTheHill extends BaseContract {
   };
 
   filters: {
-    "HighestBidIncreased(tuple)"(bid?: null): HighestBidIncreasedEventFilter;
+    "HighestBidIncreased((address,uint256))"(
+      bid?: null
+    ): HighestBidIncreasedEventFilter;
     HighestBidIncreased(bid?: null): HighestBidIncreasedEventFilter;
   };
 

--- a/packages/target-ethers-v5/src/codegen/events.ts
+++ b/packages/target-ethers-v5/src/codegen/events.ts
@@ -3,7 +3,7 @@ import {
   EventArgDeclaration,
   EventDeclaration,
   getFullSignatureAsSymbolForEvent,
-  getFullSignatureForEvent
+  getFullSignatureForEvent,
 } from 'typechain'
 
 import { generateInputType, generateOutputComplexTypeAsArray, generateOutputComplexTypesAsObject } from './types'
@@ -56,7 +56,7 @@ export function generateInterfaceEventDescription(event: EventDeclaration): stri
 }
 
 export function generateEventSignature(event: EventDeclaration): string {
-  return getFullSignatureForEvent(event);
+  return getFullSignatureForEvent(event)
 }
 
 export function generateEventInputs(eventArgs: EventArgDeclaration[]) {

--- a/packages/target-ethers-v5/src/codegen/events.ts
+++ b/packages/target-ethers-v5/src/codegen/events.ts
@@ -3,6 +3,7 @@ import {
   EventArgDeclaration,
   EventDeclaration,
   getFullSignatureAsSymbolForEvent,
+  getFullSignatureForEvent
 } from 'typechain'
 
 import { generateInputType, generateOutputComplexTypeAsArray, generateOutputComplexTypesAsObject } from './types'
@@ -55,7 +56,7 @@ export function generateInterfaceEventDescription(event: EventDeclaration): stri
 }
 
 export function generateEventSignature(event: EventDeclaration): string {
-  return `${event.name}(${event.inputs.map((input: any) => input.type.originalType).join(',')})`
+  return getFullSignatureForEvent(event);
 }
 
 export function generateEventInputs(eventArgs: EventArgDeclaration[]) {

--- a/packages/target-ethers-v6-test/test/Events.test.ts
+++ b/packages/target-ethers-v6-test/test/Events.test.ts
@@ -49,6 +49,20 @@ describe('Events', () => {
     })
   })
 
+  it('queryFilter ith tuples and arrays', async () => {
+    await contract.emit_event5()
+
+    const filter = contract.filters.Event5()
+    const results = await contract.queryFilter(filter)
+    typedAssert(results.length, 1)
+    results.map((r) => {
+      typedAssert(r.args[0][0][0],  BigInt(2))
+      typedAssert(r.args[0][0][1], "test")
+      typedAssert(r.args[0][1][0], BigInt(3))
+      typedAssert(r.args[0][1][1], "test2")
+    })
+  })
+
   it('contract.on', async () => {
     const filter = contract.filters.Event1(undefined, undefined)
     await contract.queryFilter(filter)

--- a/packages/target-ethers-v6-test/test/Events.test.ts
+++ b/packages/target-ethers-v6-test/test/Events.test.ts
@@ -56,10 +56,10 @@ describe('Events', () => {
     const results = await contract.queryFilter(filter)
     typedAssert(results.length, 1)
     results.map((r) => {
-      typedAssert(r.args[0][0][0],  BigInt(2))
-      typedAssert(r.args[0][0][1], "test")
+      typedAssert(r.args[0][0][0], BigInt(2))
+      typedAssert(r.args[0][0][1], 'test')
       typedAssert(r.args[0][1][0], BigInt(3))
-      typedAssert(r.args[0][1][1], "test2")
+      typedAssert(r.args[0][1][1], 'test2')
     })
   })
 

--- a/packages/target-ethers-v6-test/types/factories/v0.6.4/DataTypesInput__factory.ts
+++ b/packages/target-ethers-v6-test/types/factories/v0.6.4/DataTypesInput__factory.ts
@@ -10,6 +10,62 @@ import type {
 
 const _abi = [
   {
+    anonymous: false,
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "uint256_0",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "uint256_1",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct DataTypesInput.Struct1",
+        name: "input",
+        type: "tuple",
+      },
+    ],
+    name: "event_struct",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "input",
+        type: "uint256",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "uint256_0",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "uint256_1",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct DataTypesInput.Struct1",
+        name: "input2",
+        type: "tuple",
+      },
+    ],
+    name: "event_struct_2",
+    type: "event",
+  },
+  {
     inputs: [
       {
         internalType: "address",

--- a/packages/target-ethers-v6-test/types/factories/v0.6.4/Events__factory.ts
+++ b/packages/target-ethers-v6-test/types/factories/v0.6.4/Events__factory.ts
@@ -110,6 +110,31 @@ const _abi = [
   },
   {
     anonymous: false,
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "index",
+            type: "uint256",
+          },
+          {
+            internalType: "string",
+            name: "name",
+            type: "string",
+          },
+        ],
+        indexed: false,
+        internalType: "struct Events.EventData[2]",
+        name: "data",
+        type: "tuple[2]",
+      },
+    ],
+    name: "Event5",
+    type: "event",
+  },
+  {
+    anonymous: false,
     inputs: [],
     name: "NoArgsEvent",
     type: "event",
@@ -171,6 +196,13 @@ const _abi = [
   {
     inputs: [],
     name: "emit_event4",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "emit_event5",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/packages/target-ethers-v6-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-ethers-v6-test/types/v0.6.4/DataTypesInput.ts
@@ -8,6 +8,7 @@ import type {
   FunctionFragment,
   Result,
   Interface,
+  EventFragment,
   AddressLike,
   ContractRunner,
   ContractMethod,
@@ -17,27 +18,10 @@ import type {
   TypedContractEvent,
   TypedDeferredTopicFilter,
   TypedEventLog,
+  TypedLogDescription,
   TypedListener,
   TypedContractMethod,
 } from "../common";
-
-export declare namespace StructsLib1 {
-  export type InfoStruct = { a: BigNumberish; b: BigNumberish };
-
-  export type InfoStructOutput = [a: bigint, b: bigint] & {
-    a: bigint;
-    b: bigint;
-  };
-}
-
-export declare namespace StructsLib2 {
-  export type InfoStruct = { a: AddressLike; b: AddressLike };
-
-  export type InfoStructOutput = [a: string, b: string] & {
-    a: string;
-    b: string;
-  };
-}
 
 export declare namespace DataTypesInput {
   export type Struct1Struct = {
@@ -63,6 +47,24 @@ export declare namespace DataTypesInput {
   export type Struct3Struct = { input1: BigNumberish[] };
 
   export type Struct3StructOutput = [input1: bigint[]] & { input1: bigint[] };
+}
+
+export declare namespace StructsLib1 {
+  export type InfoStruct = { a: BigNumberish; b: BigNumberish };
+
+  export type InfoStructOutput = [a: bigint, b: bigint] & {
+    a: bigint;
+    b: bigint;
+  };
+}
+
+export declare namespace StructsLib2 {
+  export type InfoStruct = { a: AddressLike; b: AddressLike };
+
+  export type InfoStructOutput = [a: string, b: string] & {
+    a: string;
+    b: string;
+  };
 }
 
 export interface DataTypesInputInterface extends Interface {
@@ -97,6 +99,10 @@ export interface DataTypesInputInterface extends Interface {
       | "input_uint8"
       | "input_uint_array"
   ): FunctionFragment;
+
+  getEvent(
+    nameOrSignatureOrTopic: "event_struct" | "event_struct_2"
+  ): EventFragment;
 
   encodeFunctionData(
     functionFragment: "input_address",
@@ -359,6 +365,37 @@ export interface DataTypesInputInterface extends Interface {
     functionFragment: "input_uint_array",
     data: BytesLike
   ): Result;
+}
+
+export namespace event_structEvent {
+  export type InputTuple = [input: DataTypesInput.Struct1Struct];
+  export type OutputTuple = [input: DataTypesInput.Struct1StructOutput];
+  export interface OutputObject {
+    input: DataTypesInput.Struct1StructOutput;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace event_struct_2Event {
+  export type InputTuple = [
+    input: BigNumberish,
+    input2: DataTypesInput.Struct1Struct
+  ];
+  export type OutputTuple = [
+    input: bigint,
+    input2: DataTypesInput.Struct1StructOutput
+  ];
+  export interface OutputObject {
+    input: bigint;
+    input2: DataTypesInput.Struct1StructOutput;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
 }
 
 export interface DataTypesInput extends BaseContract {
@@ -997,5 +1034,42 @@ export interface DataTypesInput extends BaseContract {
     nameOrSignature: "input_uint_array"
   ): TypedContractMethod<[input1: BigNumberish[]], [bigint[]], "view">;
 
-  filters: {};
+  getEvent(
+    key: "event_struct"
+  ): TypedContractEvent<
+    event_structEvent.InputTuple,
+    event_structEvent.OutputTuple,
+    event_structEvent.OutputObject
+  >;
+  getEvent(
+    key: "event_struct_2"
+  ): TypedContractEvent<
+    event_struct_2Event.InputTuple,
+    event_struct_2Event.OutputTuple,
+    event_struct_2Event.OutputObject
+  >;
+
+  filters: {
+    "event_struct(tuple)": TypedContractEvent<
+      event_structEvent.InputTuple,
+      event_structEvent.OutputTuple,
+      event_structEvent.OutputObject
+    >;
+    event_struct: TypedContractEvent<
+      event_structEvent.InputTuple,
+      event_structEvent.OutputTuple,
+      event_structEvent.OutputObject
+    >;
+
+    "event_struct_2(uint256,tuple)": TypedContractEvent<
+      event_struct_2Event.InputTuple,
+      event_struct_2Event.OutputTuple,
+      event_struct_2Event.OutputObject
+    >;
+    event_struct_2: TypedContractEvent<
+      event_struct_2Event.InputTuple,
+      event_struct_2Event.OutputTuple,
+      event_struct_2Event.OutputObject
+    >;
+  };
 }

--- a/packages/target-ethers-v6-test/types/v0.6.4/Events.ts
+++ b/packages/target-ethers-v6-test/types/v0.6.4/Events.ts
@@ -41,6 +41,7 @@ export interface EventsInterface extends Interface {
       | "emit_event3"
       | "emit_event3_overloaded"
       | "emit_event4"
+      | "emit_event5"
   ): FunctionFragment;
 
   getEvent(
@@ -51,6 +52,7 @@ export interface EventsInterface extends Interface {
       | "Event3(bool,uint256)"
       | "Event3(uint256)"
       | "Event4"
+      | "Event5"
       | "NoArgsEvent"
       | "UpdateFrequencySet"
   ): EventFragment;
@@ -79,6 +81,10 @@ export interface EventsInterface extends Interface {
     functionFragment: "emit_event4",
     values?: undefined
   ): string;
+  encodeFunctionData(
+    functionFragment: "emit_event5",
+    values?: undefined
+  ): string;
 
   decodeFunctionResult(functionFragment: "emit_anon1", data: BytesLike): Result;
   decodeFunctionResult(
@@ -99,6 +105,10 @@ export interface EventsInterface extends Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "emit_event4",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "emit_event5",
     data: BytesLike
   ): Result;
 }
@@ -170,6 +180,22 @@ export namespace Event4Event {
   export type OutputTuple = [data: Events.EventDataStructOutput];
   export interface OutputObject {
     data: Events.EventDataStructOutput;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace Event5Event {
+  export type InputTuple = [
+    data: [Events.EventDataStruct, Events.EventDataStruct]
+  ];
+  export type OutputTuple = [
+    data: [Events.EventDataStructOutput, Events.EventDataStructOutput]
+  ];
+  export interface OutputObject {
+    data: [Events.EventDataStructOutput, Events.EventDataStructOutput];
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -255,6 +281,8 @@ export interface Events extends BaseContract {
 
   emit_event4: TypedContractMethod<[], [void], "nonpayable">;
 
+  emit_event5: TypedContractMethod<[], [void], "nonpayable">;
+
   getFunction<T extends ContractMethod = ContractMethod>(
     key: string | FunctionFragment
   ): T;
@@ -276,6 +304,9 @@ export interface Events extends BaseContract {
   ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
     nameOrSignature: "emit_event4"
+  ): TypedContractMethod<[], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "emit_event5"
   ): TypedContractMethod<[], [void], "nonpayable">;
 
   getEvent(
@@ -319,6 +350,13 @@ export interface Events extends BaseContract {
     Event4Event.InputTuple,
     Event4Event.OutputTuple,
     Event4Event.OutputObject
+  >;
+  getEvent(
+    key: "Event5"
+  ): TypedContractEvent<
+    Event5Event.InputTuple,
+    Event5Event.OutputTuple,
+    Event5Event.OutputObject
   >;
   getEvent(
     key: "NoArgsEvent"
@@ -389,6 +427,17 @@ export interface Events extends BaseContract {
       Event4Event.InputTuple,
       Event4Event.OutputTuple,
       Event4Event.OutputObject
+    >;
+
+    "Event5(tuple[2])": TypedContractEvent<
+      Event5Event.InputTuple,
+      Event5Event.OutputTuple,
+      Event5Event.OutputObject
+    >;
+    Event5: TypedContractEvent<
+      Event5Event.InputTuple,
+      Event5Event.OutputTuple,
+      Event5Event.OutputObject
     >;
 
     "NoArgsEvent()": TypedContractEvent<

--- a/packages/target-truffle-v5-test/types/truffle-contracts/DataTypesInput.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/DataTypesInput.d.ts
@@ -10,7 +10,25 @@ export interface DataTypesInputContract
   "new"(meta?: Truffle.TransactionDetails): Promise<DataTypesInputInstance>;
 }
 
-type AllEvents = never;
+export interface event_struct {
+  name: "event_struct";
+  args: {
+    input: { uint256_0: BN; uint256_1: BN };
+    0: { uint256_0: BN; uint256_1: BN };
+  };
+}
+
+export interface event_struct_2 {
+  name: "event_struct_2";
+  args: {
+    input: BN;
+    input2: { uint256_0: BN; uint256_1: BN };
+    0: BN;
+    1: { uint256_0: BN; uint256_1: BN };
+  };
+}
+
+type AllEvents = event_struct | event_struct_2;
 
 export interface DataTypesInputInstance extends Truffle.ContractInstance {
   input_uint8(

--- a/packages/target-truffle-v5-test/types/truffle-contracts/Events.d.ts
+++ b/packages/target-truffle-v5-test/types/truffle-contracts/Events.d.ts
@@ -62,6 +62,14 @@ export interface Event4 {
   };
 }
 
+export interface Event5 {
+  name: "Event5";
+  args: {
+    data: { index: BN; name: string }[];
+    0: { index: BN; name: string }[];
+  };
+}
+
 export interface NoArgsEvent {
   name: "NoArgsEvent";
   args: {};
@@ -80,6 +88,7 @@ type AllEvents =
   | Event2
   | Event3
   | Event4
+  | Event5
   | NoArgsEvent
   | UpdateFrequencySet;
 
@@ -138,6 +147,15 @@ export interface EventsInstance extends Truffle.ContractInstance {
     estimateGas(txDetails?: Truffle.TransactionDetails): Promise<number>;
   };
 
+  emit_event5: {
+    (txDetails?: Truffle.TransactionDetails): Promise<
+      Truffle.TransactionResponse<AllEvents>
+    >;
+    call(txDetails?: Truffle.TransactionDetails): Promise<void>;
+    sendTransaction(txDetails?: Truffle.TransactionDetails): Promise<string>;
+    estimateGas(txDetails?: Truffle.TransactionDetails): Promise<number>;
+  };
+
   methods: {
     emit_event1: {
       (txDetails?: Truffle.TransactionDetails): Promise<
@@ -185,6 +203,15 @@ export interface EventsInstance extends Truffle.ContractInstance {
     };
 
     emit_event4: {
+      (txDetails?: Truffle.TransactionDetails): Promise<
+        Truffle.TransactionResponse<AllEvents>
+      >;
+      call(txDetails?: Truffle.TransactionDetails): Promise<void>;
+      sendTransaction(txDetails?: Truffle.TransactionDetails): Promise<string>;
+      estimateGas(txDetails?: Truffle.TransactionDetails): Promise<number>;
+    };
+
+    emit_event5: {
       (txDetails?: Truffle.TransactionDetails): Promise<
         Truffle.TransactionResponse<AllEvents>
       >;

--- a/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/DataTypesInput.ts
@@ -21,6 +21,17 @@ export interface EventOptions {
   topics?: string[];
 }
 
+export type event_struct = ContractEventLog<{
+  input: [string, string];
+  0: [string, string];
+}>;
+export type event_struct_2 = ContractEventLog<{
+  input: string;
+  input2: [string, string];
+  0: string;
+  1: [string, string];
+}>;
+
 export interface DataTypesInput extends BaseContract {
   constructor(
     jsonInterface: any[],
@@ -147,6 +158,32 @@ export interface DataTypesInput extends BaseContract {
     ): NonPayableTransactionObject<string[]>;
   };
   events: {
+    event_struct(cb?: Callback<event_struct>): EventEmitter;
+    event_struct(
+      options?: EventOptions,
+      cb?: Callback<event_struct>
+    ): EventEmitter;
+
+    event_struct_2(cb?: Callback<event_struct_2>): EventEmitter;
+    event_struct_2(
+      options?: EventOptions,
+      cb?: Callback<event_struct_2>
+    ): EventEmitter;
+
     allEvents(options?: EventOptions, cb?: Callback<EventLog>): EventEmitter;
   };
+
+  once(event: "event_struct", cb: Callback<event_struct>): void;
+  once(
+    event: "event_struct",
+    options: EventOptions,
+    cb: Callback<event_struct>
+  ): void;
+
+  once(event: "event_struct_2", cb: Callback<event_struct_2>): void;
+  once(
+    event: "event_struct_2",
+    options: EventOptions,
+    cb: Callback<event_struct_2>
+  ): void;
 }

--- a/packages/target-web3-v1-test/types/v0.6.4/Events.ts
+++ b/packages/target-web3-v1-test/types/v0.6.4/Events.ts
@@ -48,6 +48,10 @@ export type Event4 = ContractEventLog<{
   data: [string, string];
   0: [string, string];
 }>;
+export type Event5 = ContractEventLog<{
+  data: [string, string][];
+  0: [string, string][];
+}>;
 export type NoArgsEvent = ContractEventLog<{}>;
 export type UpdateFrequencySet = ContractEventLog<{
   0: string[];
@@ -73,6 +77,8 @@ export interface Events extends BaseContract {
     emit_event3_overloaded(): NonPayableTransactionObject<void>;
 
     emit_event4(): NonPayableTransactionObject<void>;
+
+    emit_event5(): NonPayableTransactionObject<void>;
   };
   events: {
     Event1(cb?: Callback<Event1>): EventEmitter;
@@ -95,6 +101,9 @@ export interface Events extends BaseContract {
 
     Event4(cb?: Callback<Event4>): EventEmitter;
     Event4(options?: EventOptions, cb?: Callback<Event4>): EventEmitter;
+
+    Event5(cb?: Callback<Event5>): EventEmitter;
+    Event5(options?: EventOptions, cb?: Callback<Event5>): EventEmitter;
 
     NoArgsEvent(cb?: Callback<NoArgsEvent>): EventEmitter;
     NoArgsEvent(
@@ -119,6 +128,9 @@ export interface Events extends BaseContract {
 
   once(event: "Event4", cb: Callback<Event4>): void;
   once(event: "Event4", options: EventOptions, cb: Callback<Event4>): void;
+
+  once(event: "Event5", cb: Callback<Event5>): void;
+  once(event: "Event5", options: EventOptions, cb: Callback<Event5>): void;
 
   once(event: "NoArgsEvent", cb: Callback<NoArgsEvent>): void;
   once(

--- a/packages/typechain/src/utils/signatures.ts
+++ b/packages/typechain/src/utils/signatures.ts
@@ -1,5 +1,5 @@
 import { AbiParameter, EventArgDeclaration, EventDeclaration, FunctionDeclaration } from '../parser/abiParser'
-import { ArrayType,TupleType } from '../parser/parseEvmType'
+import { ArrayType, TupleType } from '../parser/parseEvmType'
 
 export function getFullSignatureAsSymbolForEvent(event: EventDeclaration): string {
   return `${event.name}_${event.inputs
@@ -26,8 +26,8 @@ export function getArgumentForSignature(argument: EventArgDeclaration | AbiParam
   if (argument.type.originalType === 'tuple') {
     return `(${(argument.type as TupleType).components.map((i) => getArgumentForSignature(i)).join(',')})`
   } else if (argument.type.originalType.startsWith('tuple')) {
-    const arr = argument.type as ArrayType;
-    return `${getArgumentForSignature({ name: '', type: arr.itemType })}[${arr.size?.toString() || ''}]`;
+    const arr = argument.type as ArrayType
+    return `${getArgumentForSignature({ name: '', type: arr.itemType })}[${arr.size?.toString() || ''}]`
   } else {
     return argument.type.originalType
   }

--- a/packages/typechain/src/utils/signatures.ts
+++ b/packages/typechain/src/utils/signatures.ts
@@ -1,5 +1,5 @@
-import { AbiParameter, EventDeclaration, FunctionDeclaration } from '../parser/abiParser'
-import { ArrayType, TupleType } from '../parser/parseEvmType'
+import { AbiParameter, EventArgDeclaration, EventDeclaration, FunctionDeclaration } from '../parser/abiParser'
+import { ArrayType,TupleType } from '../parser/parseEvmType'
 
 export function getFullSignatureAsSymbolForEvent(event: EventDeclaration): string {
   return `${event.name}_${event.inputs
@@ -14,19 +14,20 @@ export function getFullSignatureAsSymbolForEvent(event: EventDeclaration): strin
 }
 
 export function getFullSignatureForEvent(event: EventDeclaration): string {
-  return `${event.name}(${event.inputs.map((e) => e.type.originalType).join(',')})`
+  return `${event.name}(${event.inputs.map((e) => getArgumentForSignature(e)).join(',')})`
 }
 
 export function getIndexedSignatureForEvent(event: EventDeclaration): string {
   const indexedType = event.inputs.filter((e) => e.isIndexed)
-  return `${event.name}(${indexedType.map((e) => e.type.originalType).join(',')})`
+  return `${event.name}(${indexedType.map((e) => getArgumentForSignature(e)).join(',')})`
 }
 
-export function getArgumentForSignature(argument: AbiParameter): string {
+export function getArgumentForSignature(argument: EventArgDeclaration | AbiParameter): string {
   if (argument.type.originalType === 'tuple') {
     return `(${(argument.type as TupleType).components.map((i) => getArgumentForSignature(i)).join(',')})`
-  } else if (argument.type.originalType === 'tuple[]') {
-    return getArgumentForSignature({ name: '', type: (argument.type as ArrayType).itemType }) + '[]'
+  } else if (argument.type.originalType.startsWith('tuple')) {
+    const arr = argument.type as ArrayType;
+    return `${getArgumentForSignature({ name: '', type: arr.itemType })}[${arr.size?.toString() || ''}]`;
   } else {
     return argument.type.originalType
   }


### PR DESCRIPTION
Expands on https://github.com/dethcrypto/TypeChain/pull/488 to add the some functionality for events. 

Fixes https://github.com/dethcrypto/TypeChain/issues/785 and https://github.com/dethcrypto/TypeChain/issues/433 which might have been a regression. 

Added a bit more tests, also added a test to `ethers-v6` to make sure it already works as expected.