### PR TITLE
Add directory exports module suffix

### DIFF
--- a/.changeset/lazy-eggs-brush.md
+++ b/.changeset/lazy-eggs-brush.md
@@ -1,0 +1,6 @@
+---
+'typechain': patch
+---
+
+Add the node16 moduleSuffix also to directories (including the `index` filename) as in ESM directory root files have to
+be explicitly stated (including their file extension).

--- a/examples/ethers-v5-nodenext/types/ethers-contracts/index.ts
+++ b/examples/ethers-v5-nodenext/types/ethers-contracts/index.ts
@@ -2,5 +2,5 @@
 /* tslint:disable */
 /* eslint-disable */
 export type { Dai } from "./Dai.js";
-export * as factories from "./factories";
+export * as factories from "./factories/index.js";
 export { Dai__factory } from "./factories/Dai__factory.js";

--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -59,6 +59,9 @@ export function createBarrelFiles(
             `export type { ${namespaceIdentifier} };`,
           ].join('\n')
 
+        if (moduleSuffix) {
+          return `export * as ${namespaceIdentifier} from './${p}/index${moduleSuffix}';`
+        }
         return `export * as ${namespaceIdentifier} from './${p}';`
       })
       .join('\n')


### PR DESCRIPTION
This adds a proper suffix to directory imports as well (as long as they are actual files and not types).

This should close #819.