### PR TITLE
fix: [ethers-v6] codegen/hardhat.ts DeployContractOptions expected

### DIFF
--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -11,7 +11,7 @@
     "typecheck": "pnpm compile && pnpm test && pnpm tsc --noEmit"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-ethers": "^3.0.0",
+    "@nomicfoundation/hardhat-ethers": "^3.0.4",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@typechain/ethers-v6": "workspace:^0.4.0",
     "@typechain/hardhat": "workspace:^8.0.0",

--- a/examples/hardhat/test/counter.ts
+++ b/examples/hardhat/test/counter.ts
@@ -2,6 +2,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { solidity } from 'ethereum-waffle'
 import { ethers } from 'hardhat'
+import { DeployContractOptions } from "@nomicfoundation/hardhat-ethers/types"
 
 import type { Counter } from '../typechain-types'
 
@@ -17,13 +18,15 @@ describe('Counter', () => {
     const signers = await ethers.getSigners()
 
     // 2
-    counter = await ethers.deployContract('Counter')
-
+    const gasPrice = 1637083528
+    const options: DeployContractOptions = { gasPrice }
+    counter = await ethers.deployContract('Counter', options)
     const initialCount = await counter.getCount()
 
     // 3
     expect(initialCount).to.eq(0)
     expect(await counter.getAddress()).to.properAddress
+    expect(counter.deploymentTransaction()?.gasPrice).to.eq(gasPrice)
   })
 
   // 4

--- a/packages/hardhat-test/typechain-types/hardhat.d.ts
+++ b/packages/hardhat-test/typechain-types/hardhat.d.ts
@@ -4,6 +4,7 @@
 
 import { ethers } from "ethers";
 import {
+  DeployContractOptions,
   FactoryOptions,
   HardhatEthersHelpers as HardhatEthersHelpersBase,
 } from "@nomicfoundation/hardhat-ethers/types";
@@ -52,40 +53,40 @@ declare module "hardhat/types/runtime" {
 
     deployContract(
       name: "Counter",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Counter>;
     deployContract(
       name: "Demo",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Demo>;
     deployContract(
       name: "Hello",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Hello>;
     deployContract(
       name: "StructsInConstructor",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.StructsInConstructor>;
 
     deployContract(
       name: "Counter",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Counter>;
     deployContract(
       name: "Demo",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Demo>;
     deployContract(
       name: "Hello",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.Hello>;
     deployContract(
       name: "StructsInConstructor",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.StructsInConstructor>;
 
     // default types
@@ -105,12 +106,12 @@ declare module "hardhat/types/runtime" {
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
   }
 }

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain-types/hardhat.d.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain-types/hardhat.d.ts
@@ -4,6 +4,7 @@
 
 import { ethers } from "ethers";
 import {
+  DeployContractOptions,
   FactoryOptions,
   HardhatEthersHelpers as HardhatEthersHelpersBase,
 } from "@nomicfoundation/hardhat-ethers/types";
@@ -61,49 +62,49 @@ declare module "hardhat/types/runtime" {
 
     deployContract(
       name: "EdgeCases",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.EdgeCases>;
     deployContract(
       name: "SafeMath",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.SafeMath>;
     deployContract(
       name: "TestContract",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.TestContract>;
     deployContract(
       name: "TestContract1",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.TestContract1>;
     deployContract(
       name: "ERC20",
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.ERC20>;
 
     deployContract(
       name: "EdgeCases",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.EdgeCases>;
     deployContract(
       name: "SafeMath",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.SafeMath>;
     deployContract(
       name: "TestContract",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.TestContract>;
     deployContract(
       name: "TestContract1",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.TestContract1>;
     deployContract(
       name: "ERC20",
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<Contracts.ERC20>;
 
     // default types
@@ -123,12 +124,12 @@ declare module "hardhat/types/runtime" {
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
   }
 }

--- a/packages/target-ethers-v6/src/codegen/hardhat.ts
+++ b/packages/target-ethers-v6/src/codegen/hardhat.ts
@@ -5,7 +5,7 @@ export function generateHardhatHelper(contracts: string[]): string {
   return `
 
 import { ethers } from 'ethers'
-import { FactoryOptions, HardhatEthersHelpers as HardhatEthersHelpersBase} from "@nomicfoundation/hardhat-ethers/types";
+import { DeployContractOptions, FactoryOptions, HardhatEthersHelpers as HardhatEthersHelpersBase} from "@nomicfoundation/hardhat-ethers/types";
 
 import * as Contracts from "."
 
@@ -29,14 +29,15 @@ declare module "hardhat/types/runtime" {
 
   ${contracts
     .map(
-      (n) => `deployContract(name: '${n}', signerOrOptions?: ethers.Signer | FactoryOptions): Promise<Contracts.${n}>`,
+      (n) =>
+        `deployContract(name: '${n}', signerOrOptions?: ethers.Signer | DeployContractOptions): Promise<Contracts.${n}>`,
     )
     .join('\n')}
 
   ${contracts
     .map(
       (n) =>
-        `deployContract(name: '${n}', args: any[], signerOrOptions?: ethers.Signer | FactoryOptions): Promise<Contracts.${n}>`,
+        `deployContract(name: '${n}', args: any[], signerOrOptions?: ethers.Signer | DeployContractOptions): Promise<Contracts.${n}>`,
     )
     .join('\n')}
 
@@ -57,12 +58,12 @@ declare module "hardhat/types/runtime" {
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
     deployContract(
       name: string,
       args: any[],
-      signerOrOptions?: ethers.Signer | FactoryOptions
+      signerOrOptions?: ethers.Signer | DeployContractOptions
     ): Promise<ethers.Contract>;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,10 +147,10 @@ importers:
         version: 5.4.0
       '@nomicfoundation/hardhat-chai-matchers':
         specifier: ^2.0.0
-        version: 2.0.0(@nomicfoundation/hardhat-ethers@3.0.0)(chai@4.3.6)(ethers@6.3.0)(hardhat@2.9.9)
+        version: 2.0.0(@nomicfoundation/hardhat-ethers@3.0.4)(chai@4.3.6)(ethers@6.3.0)(hardhat@2.9.9)
       '@nomicfoundation/hardhat-ethers':
-        specifier: ^3.0.0
-        version: 3.0.0(ethers@6.3.0)(hardhat@2.9.9)
+        specifier: ^3.0.4
+        version: 3.0.4(ethers@6.3.0)(hardhat@2.9.9)
       '@typechain/ethers-v6':
         specifier: workspace:^0.4.0
         version: link:../../packages/target-ethers-v6
@@ -2004,7 +2004,7 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@nomicfoundation/hardhat-chai-matchers@2.0.0(@nomicfoundation/hardhat-ethers@3.0.0)(chai@4.3.6)(ethers@6.3.0)(hardhat@2.9.9):
+  /@nomicfoundation/hardhat-chai-matchers@2.0.0(@nomicfoundation/hardhat-ethers@3.0.4)(chai@4.3.6)(ethers@6.3.0)(hardhat@2.9.9):
     resolution: {integrity: sha512-e2ZFunJBIWDcFKIxQt6GpFRRKUn8ZshoiZ5cmgaKOR1S9XwimiCs2aLUCZ/xjNrdl049kPqdVKYDj6aYeR6WuQ==}
     peerDependencies:
       '@nomicfoundation/hardhat-ethers': ^3.0.0
@@ -2013,7 +2013,7 @@ packages:
       hardhat: ^2.9.4
     dependencies:
       '@ethersproject/abi': 5.6.0
-      '@nomicfoundation/hardhat-ethers': 3.0.0(ethers@6.3.0)(hardhat@2.9.9)
+      '@nomicfoundation/hardhat-ethers': 3.0.4(ethers@6.3.0)(hardhat@2.9.9)
       '@types/chai-as-promised': 7.1.5
       chai: 4.3.6
       chai-as-promised: 7.1.1(chai@4.3.6)
@@ -2030,7 +2030,21 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       ethers: 6.3.0
+      hardhat: 2.9.9(ts-node@10.7.0)(typescript@4.6.2)
+    dev: true
+
+  /@nomicfoundation/hardhat-ethers@3.0.4(ethers@6.3.0)(hardhat@2.9.9):
+    resolution: {integrity: sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==}
+    peerDependencies:
+      ethers: ^6.1.0
+      hardhat: ^2.0.0
+    dependencies:
+      debug: 4.3.3(supports-color@8.1.1)
+      ethers: 6.3.0
       hardhat: 2.9.9(ts-node@10.7.0)(typescript@4.9.5)
+      lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@nomiclabs/hardhat-etherscan@2.1.8(hardhat@2.9.9):
@@ -10115,8 +10129,7 @@ packages:
     dev: true
 
   /lodash.isequal@4.5.0:
-    resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
-    optional: true
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
 
   /lodash.keys@4.2.0:
     resolution: {integrity: sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=}


### PR DESCRIPTION
## Issue
[@nomicfoundation/hardhat-ethers@3.0.1](https://github.com/NomicFoundation/hardhat/releases/tag/%40nomicfoundation%2Fhardhat-ethers%403.0.1) added support for transaction overrides in the `deployContract` helper.

Specifically, these are the changes  https://github.com/NomicFoundation/hardhat/commit/d8056fb8bc1116338f61974a8a44cd0defcb2555.

Here's issue raised in `hardhat` repository:
- https://github.com/NomicFoundation/hardhat/issues/4118

## Fix
Replaced `FactoryOptions` with `DeployContractOptions`, and added import for it. Reran the tests to fix other files.

## Context
A new project is created:
```sh
npm init -y
npm install --save-dev hardhat
npx hardhat # Create a TypeScript project
npx hardhat compile
```

It installs `@nomicfoundation/hardhat-ethers" v3.0.4. As hardhat uses [@typechain/ethers-v6](https://github.com/NomicFoundation/hardhat/blob/c2943366d4f16282c10f92f9f216ac08130a0eb4/yarn.lock#L1672), I've only updated `packages/target-ethers-v6/src/codegen/hardhat.ts`, which should be enough to resolve the issue.

The provided `scripts/deploy.ts` contains:
```ts
import { ethers } from "hardhat";

async function main() {
  const currentTimestampInSeconds = Math.round(Date.now() / 1000);
  const unlockTime = currentTimestampInSeconds + 60;

  const lockedAmount = ethers.parseEther("0.001");

  const lock = await ethers.deployContract("Lock", [unlockTime], {
    value: lockedAmount,
  });
```

IDE complains about `{ value: lockedAmount }`. Third parameter in `ethers.deployContract` used to be for `signerOrOptions?: ethers.Signer | FactoryOptions` but was changed to `signerOrOptions?: ethers.Signer | DeployContractOptions`

Visual Studio Code:
```
No overload matches this call.
  Overload 1 of 4, '(name: "Lock", args: any[], signerOrOptions?: Signer | FactoryOptions | undefined): Promise<Lock>', gave the following error.
    Argument of type '{ value: bigint; }' is not assignable to parameter of type 'Signer | FactoryOptions | undefined'.
      Object literal may only specify known properties, and 'value' does not exist in type 'Signer | FactoryOptions'.
```
