### PR TITLE
fix(ethers-v6): always use view overrides for statcCalls

### DIFF
--- a/.changeset/honest-readers-join.md
+++ b/.changeset/honest-readers-join.md
@@ -1,0 +1,5 @@
+---
+"@typechain/ethers-v6": patch
+---
+
+ethers-v6: added new reserved keywords labels

--- a/.changeset/moody-lamps-mix.md
+++ b/.changeset/moody-lamps-mix.md
@@ -1,0 +1,5 @@
+---
+"@typechain/ethers-v6": patch
+---
+
+fix: always use view overrides for statcCalls

--- a/examples/ethers-v6/types/ethers-contracts/common.ts
+++ b/examples/ethers-v6/types/ethers-contracts/common.ts
@@ -122,8 +122,10 @@ export interface TypedContractMethod<
   populateTransaction(
     ...args: ContractMethodArgs<A, S>
   ): Promise<ContractTransaction>;
-  staticCall(...args: ContractMethodArgs<A, S>): Promise<DefaultReturnType<R>>;
+  staticCall(
+    ...args: ContractMethodArgs<A, "view">
+  ): Promise<DefaultReturnType<R>>;
   send(...args: ContractMethodArgs<A, S>): Promise<ContractTransactionResponse>;
   estimateGas(...args: ContractMethodArgs<A, S>): Promise<bigint>;
-  staticCallResult(...args: ContractMethodArgs<A, S>): Promise<R>;
+  staticCallResult(...args: ContractMethodArgs<A, "view">): Promise<R>;
 }

--- a/packages/hardhat-test/typechain-types/common.ts
+++ b/packages/hardhat-test/typechain-types/common.ts
@@ -122,8 +122,10 @@ export interface TypedContractMethod<
   populateTransaction(
     ...args: ContractMethodArgs<A, S>
   ): Promise<ContractTransaction>;
-  staticCall(...args: ContractMethodArgs<A, S>): Promise<DefaultReturnType<R>>;
+  staticCall(
+    ...args: ContractMethodArgs<A, "view">
+  ): Promise<DefaultReturnType<R>>;
   send(...args: ContractMethodArgs<A, S>): Promise<ContractTransactionResponse>;
   estimateGas(...args: ContractMethodArgs<A, S>): Promise<bigint>;
-  staticCallResult(...args: ContractMethodArgs<A, S>): Promise<R>;
+  staticCallResult(...args: ContractMethodArgs<A, "view">): Promise<R>;
 }

--- a/packages/hardhat/test/fixture-projects/hardhat-project/typechain-types/common.ts
+++ b/packages/hardhat/test/fixture-projects/hardhat-project/typechain-types/common.ts
@@ -122,8 +122,10 @@ export interface TypedContractMethod<
   populateTransaction(
     ...args: ContractMethodArgs<A, S>
   ): Promise<ContractTransaction>;
-  staticCall(...args: ContractMethodArgs<A, S>): Promise<DefaultReturnType<R>>;
+  staticCall(
+    ...args: ContractMethodArgs<A, "view">
+  ): Promise<DefaultReturnType<R>>;
   send(...args: ContractMethodArgs<A, S>): Promise<ContractTransactionResponse>;
   estimateGas(...args: ContractMethodArgs<A, S>): Promise<bigint>;
-  staticCallResult(...args: ContractMethodArgs<A, S>): Promise<R>;
+  staticCallResult(...args: ContractMethodArgs<A, "view">): Promise<R>;
 }

--- a/packages/target-ethers-v6-test/test/Payable.test.ts
+++ b/packages/target-ethers-v6-test/test/Payable.test.ts
@@ -1,0 +1,21 @@
+import type { AssertTrue, IsExact } from 'test-utils'
+
+import type { Payable } from '../types'
+import type { PostfixOverrides } from '../types/common'
+import { createNewBlockchain } from './common'
+
+describe('Payable', () => {
+  const chain = createNewBlockchain<Payable>('Payable')
+
+  it('generate view override parameter types for staticCall', async () => {
+    type InputType = Parameters<typeof chain.contract.payable_func.staticCall>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type _t1 = AssertTrue<IsExact<InputType, PostfixOverrides<[], 'view'>>>
+  })
+
+  it('generate view override parameter types for staticCallResult', async () => {
+    type InputType = Parameters<typeof chain.contract.payable_func.staticCallResult>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type _t1 = AssertTrue<IsExact<InputType, PostfixOverrides<[], 'view'>>>
+  })
+})

--- a/packages/target-ethers-v6-test/types/common.ts
+++ b/packages/target-ethers-v6-test/types/common.ts
@@ -122,8 +122,10 @@ export interface TypedContractMethod<
   populateTransaction(
     ...args: ContractMethodArgs<A, S>
   ): Promise<ContractTransaction>;
-  staticCall(...args: ContractMethodArgs<A, S>): Promise<DefaultReturnType<R>>;
+  staticCall(
+    ...args: ContractMethodArgs<A, "view">
+  ): Promise<DefaultReturnType<R>>;
   send(...args: ContractMethodArgs<A, S>): Promise<ContractTransactionResponse>;
   estimateGas(...args: ContractMethodArgs<A, S>): Promise<bigint>;
-  staticCallResult(...args: ContractMethodArgs<A, S>): Promise<R>;
+  staticCallResult(...args: ContractMethodArgs<A, "view">): Promise<R>;
 }

--- a/packages/target-ethers-v6/static/common.ts
+++ b/packages/target-ethers-v6/static/common.ts
@@ -82,8 +82,8 @@ export interface TypedContractMethod<
   getFragment(...args: ContractMethodArgs<A, S>): FunctionFragment
 
   populateTransaction(...args: ContractMethodArgs<A, S>): Promise<ContractTransaction>
-  staticCall(...args: ContractMethodArgs<A, S>): Promise<DefaultReturnType<R>>
+  staticCall(...args: ContractMethodArgs<A, 'view'>): Promise<DefaultReturnType<R>>
   send(...args: ContractMethodArgs<A, S>): Promise<ContractTransactionResponse>
   estimateGas(...args: ContractMethodArgs<A, S>): Promise<bigint>
-  staticCallResult(...args: ContractMethodArgs<A, S>): Promise<R>
+  staticCallResult(...args: ContractMethodArgs<A, 'view'>): Promise<R>
 }


### PR DESCRIPTION
Fixes: https://github.com/dethcrypto/TypeChain/issues/861

The overrides for static call functions should always be view overrides in order to use properties like `blockTag`.