### PR TITLE
Normalize dirname

### DIFF
--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -1,8 +1,9 @@
-import { camelCase, groupBy, mapValues, uniq } from 'lodash'
+import { groupBy, mapValues, uniq } from 'lodash'
 import { posix } from 'path'
 
 import { normalizeName } from '../parser/normalizeName'
 import { FileDescription } from '../typechain/types'
+import {normalizeDirName} from "./normalizeDirName";
 
 /**
  * returns barrel files with reexports for all given paths
@@ -51,7 +52,7 @@ export function createBarrelFiles(
 
     const namespacesExports = nestedDirs
       .map((p) => {
-        const namespaceIdentifier = camelCase(p)
+        const namespaceIdentifier = normalizeDirName(p)
 
         if (typeOnly)
           return [

--- a/packages/typechain/src/codegen/normalizeDirName.ts
+++ b/packages/typechain/src/codegen/normalizeDirName.ts
@@ -1,0 +1,13 @@
+import { camelCase } from 'lodash'
+
+/**
+ * Converts valid directory name to valid variable name. Example: 0directory-name becomes _0directoryName
+ */
+export function normalizeDirName(rawName: string): string {
+    const transformations: ((s: string) => string)[] = [
+        (s) => camelCase(s), // convert to camelCase
+        (s) => s.replace(/^\d/g, (match) => "_" + match), // prepend '_' if contains a leading number
+    ]
+
+    return transformations.reduce((s, t) => t(s), rawName)
+}

--- a/packages/typechain/src/codegen/normalizeDirName.ts
+++ b/packages/typechain/src/codegen/normalizeDirName.ts
@@ -1,7 +1,7 @@
 import { camelCase } from 'lodash'
 
 /**
- * Converts valid directory name to valid variable name. Example: 0directory-name becomes _0directoryName
+ * Converts valid directory name to valid variable name. Example: 0directory-name becomes _0DirectoryName
  */
 export function normalizeDirName(rawName: string): string {
     const transformations: ((s: string) => string)[] = [

--- a/packages/typechain/test/codegen/normalizeDirName.test.ts
+++ b/packages/typechain/test/codegen/normalizeDirName.test.ts
@@ -1,0 +1,13 @@
+import { expect } from 'earljs'
+import {normalizeDirName} from "../../src/codegen/normalizeDirName";
+
+describe('dir name normalizer', () => {
+    it('should work', () => {
+        expect(normalizeDirName('dirname')).toEqual('dirname')
+        expect(normalizeDirName('dir_name')).toEqual('dirName')
+        expect(normalizeDirName('0.4.24')).toEqual('_0424')
+        expect(normalizeDirName('0-4-24')).toEqual('_0424')
+        expect(normalizeDirName('0424')).toEqual('_0424')
+        expect(normalizeDirName('0dir-name.1')).toEqual('_0DirName1')
+    })
+})

--- a/packages/typechain/test/codegen/normalizeDirName.test.ts
+++ b/packages/typechain/test/codegen/normalizeDirName.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'earljs'
+
 import {normalizeDirName} from "../../src/codegen/normalizeDirName";
 
 describe('dir name normalizer', () => {


### PR DESCRIPTION
This PR fixes an issue where generating a variable name from a directory name starting with a digit causes the invalid syntax error (see pic below).

<img width="354" alt="image" src="https://github.com/dethcrypto/TypeChain/assets/39704351/15b0806a-c6da-4d74-9e98-c5b4f1efa11e">


For instance, we organize Solidity files in directories by the version used, e.g. `0.4.24`, `0.8.9`.

## Naive solution
One simple solution would be to rename the directory to something like `v0.4.24`. However, we have verified our Solidity source code on Etherscan with this directory structure. If we rename the directories, we risk breaking our verification. This is why we can't use this approach.

## Our solution

We propose normalizing the generated variable name by prepending an underscore (`_`) to the name starting with a digit.
Thus, the dirname `0.4.24.` becomes `_0424` which is a legal JavaScript variable name. 

<img width="695" alt="image" src="https://github.com/dethcrypto/TypeChain/assets/39704351/daef7efe-ef58-42e6-9b7f-4c2245dd9e5f">
