### PR TITLE
barrel file moduleSuffix for type exports

### DIFF
--- a/packages/typechain/src/codegen/createBarrelFiles.ts
+++ b/packages/typechain/src/codegen/createBarrelFiles.ts
@@ -53,6 +53,12 @@ export function createBarrelFiles(
       .map((p) => {
         const namespaceIdentifier = camelCase(p)
 
+        if (typeOnly && moduleSuffix)
+          return [
+            `import type * as ${namespaceIdentifier} from './${p}/index${moduleSuffix}';`,
+            `export type { ${namespaceIdentifier} };`,
+          ].join('\n')
+
         if (typeOnly)
           return [
             `import type * as ${namespaceIdentifier} from './${p}';`,


### PR DESCRIPTION
When working with [tsx](https://github.com/esbuild-kit/tsx) I get issues with ESM interoperability due to the types not using explicity import paths. This PR fixes this and makes exports more consistent such that both types & implementations are exported with explicit `moduleSuffix` if specified.