### PR TITLE
feat: add node16Modules flag for hardhat

### DIFF
--- a/.changeset/hungry-suits-check.md
+++ b/.changeset/hungry-suits-check.md
@@ -1,0 +1,5 @@
+---
+'@typechain/hardhat': minor
+---
+
+allow node6Modules for @typechain/hardhat

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -83,6 +83,7 @@ subtask(TASK_TYPECHAIN_GENERATE_TYPES)
         discriminateTypes: typechainCfg.discriminateTypes,
         tsNocheck: typechainCfg.tsNocheck,
         environment: 'hardhat',
+        node16Modules: typechainCfg.node16Modules,
       },
     }
 


### PR DESCRIPTION
This PR allows `@typechain/hardhat` to configure `node16Modules` flag so that we can generate ESM compatible code.